### PR TITLE
Add support for using LIBLINEAR as the SVM backend

### DIFF
--- a/do_my_classification.m
+++ b/do_my_classification.m
@@ -33,10 +33,10 @@ elseif STUDY.analysis_mode==3 % SVR (regression) with libsvm
 elseif STUDY.analysis_mode==4 % SVR (regression continuous) with libsvm
     model = svmtrain(Labels,Samples,'-s 3 -t 0 -c 0.1');
 elseif STUDY.analysis_mode==5 % SVM classification with liblinear
-   model = train(Labels,sparse(Samples),'-s 2 -c 1');
+   model = train(Labels,sparse(Samples),'-s 0 -c 1');
 end
 %__________________________________________________________________________    
-		
+
 %% define samples and labels for testing
 Samples=vectors_test;
 Labels=labels_test;
@@ -45,12 +45,12 @@ Labels=labels_test;
 %% prediction
 %__________________________________________________________________________
 
-if sum(STUDY.analysis_mode == [1 3 4 5]) % libsvm
+if sum(STUDY.analysis_mode == [1 3 4]) % libsvm
     [predicted_label, accuracy, decision_values] = svmpredict(Labels, Samples, model); 
 elseif sum(STUDY.analysis_mode == [2]) % LDA
     % to be implemented in a future version
 elseif sum(STUDY.analysis_mode == [5]) % liblinear
-    [predicted_label, accuracy, decision_values] = predict(Labels, Samples, model); 
+    [predicted_label, accuracy, decision_values] = predict(Labels, sparse(Samples), model); 
 end
 
 if sum(STUDY.analysis_mode==[1]) % SVM classification with libsvm
@@ -149,7 +149,7 @@ elseif sum(STUDY.analysis_mode==[5]) % SVM classification with liblinear
     % calculating feature weights
     %w = model.SVs' * model.sv_coef;
     %b = -model.rho;
-    w = model.w;
+    w = model.w';
 
     feat_weights=zeros(size(w,1),3);
     
@@ -159,6 +159,7 @@ elseif sum(STUDY.analysis_mode==[5]) % SVM classification with liblinear
         feat_weights(:,3)=abs(w);
     end
 
+    disp(accuracy)
     % extracting accuracy for 2-classes 
     if STUDY.nconds==2
 

--- a/do_my_classification.m
+++ b/do_my_classification.m
@@ -33,7 +33,7 @@ elseif STUDY.analysis_mode==3 % SVR (regression) with libsvm
 elseif STUDY.analysis_mode==4 % SVR (regression continuous) with libsvm
     model = svmtrain(Labels,Samples,'-s 3 -t 0 -c 0.1');
 elseif STUDY.analysis_mode==5 % SVM classification with liblinear
-   model = train(Labels,sparse(Samples),'-s 0 -c 1');
+   model = train(Labels,sparse(Samples),'-s 2 -c 1');
 end
 %__________________________________________________________________________    
 

--- a/do_my_classification.m
+++ b/do_my_classification.m
@@ -14,6 +14,8 @@ function [acc,feat_weights]=do_my_classification(vectors_train,labels_train,vect
 % see: https://www.csie.ntu.edu.tw/~cjlin/libsvm/
 % Chang CC, Lin CJ (2011). LIBSVM : a library for support vector machines. ACM TIST, 2(3):27,
 
+% ONLY FOR DEBUGGING
+%global model 
 
 %% define samples and labels for training
 
@@ -22,27 +24,36 @@ Labels=labels_train;
 
 %% training 
 %__________________________________________________________________________
-if STUDY.analysis_mode==1 % SVM classification
+if STUDY.analysis_mode==1 % SVM classification with libsvm
     model = svmtrain(Labels,Samples,'-s 0 -t 0 -c 1');
 elseif STUDY.analysis_mode==2 % LDA classifcation
     % to be implemented in future version
-elseif STUDY.analysis_mode==3 % SVR (regression)
+elseif STUDY.analysis_mode==3 % SVR (regression) with libsvm
     model = svmtrain(Labels,Samples,'-s 3 -t 0 -c 0.1');
-elseif STUDY.analysis_mode==4 % SVR (regression continuous)
+elseif STUDY.analysis_mode==4 % SVR (regression continuous) with libsvm
     model = svmtrain(Labels,Samples,'-s 3 -t 0 -c 0.1');
+elseif STUDY.analysis_mode==5 % SVM classification with liblinear
+   model = train(Labels,sparse(Samples),'-s 2 -c 1');
 end
 %__________________________________________________________________________    
 		
 %% define samples and labels for testing
 Samples=vectors_test;
 Labels=labels_test;
+%disp(model)
 
 %% prediction
 %__________________________________________________________________________
 
-[predicted_label, accuracy, decision_values] = svmpredict(Labels, Samples, model); 
+if sum(STUDY.analysis_mode == [1 3 4 5]) % libsvm
+    [predicted_label, accuracy, decision_values] = svmpredict(Labels, Samples, model); 
+elseif sum(STUDY.analysis_mode == [2]) % LDA
+    % to be implemented in a future version
+elseif sum(STUDY.analysis_mode == [5]) % liblinear
+    [predicted_label, accuracy, decision_values] = predict(Labels, Samples, model); 
+end
 
-if STUDY.analysis_mode==1 % SVM classification
+if sum(STUDY.analysis_mode==[1]) % SVM classification with libsvm
     
     % calculating feature weights
     w = model.SVs' * model.sv_coef;
@@ -132,6 +143,45 @@ elseif STUDY.analysis_mode==4 %SVM regression (continuous)
         feat_weights(:,2)=w;
         feat_weights(:,3)=abs(w);
     end
+    
+elseif sum(STUDY.analysis_mode==[5]) % SVM classification with liblinear
+    
+    % calculating feature weights
+    %w = model.SVs' * model.sv_coef;
+    %b = -model.rho;
+    w = model.w;
+
+    feat_weights=zeros(size(w,1),3);
+    
+    if STUDY.feat_weights_mode==1 
+        feat_weights(:,1)=1:(size(w,1));
+        feat_weights(:,2)=w;
+        feat_weights(:,3)=abs(w);
+    end
+
+    % extracting accuracy for 2-classes 
+    if STUDY.nconds==2
+
+        acc=accuracy(1);
+
+    % extracting accuracy for N-classes
+    elseif STUDY.nconds>2
+
+        classes=1:STUDY.nconds;
+        pairs=nchoosek(classes,2);
+
+        for cl=classes
+            wt(:,cl)=(pairs(:,1)==cl) - (pairs(:,2)==cl);
+        end
+
+        votes=decision_values*wt;
+        [maxvote,winvote]=max(votes');
+        classcorrectnes=(classes==winvote)*100;
+
+        acc=mean(classcorrectnes);
+
+    end % if nclass
+
     
 end
 %__________________________________________________________________________


### PR DESCRIPTION
This provides an alternative backend for SVM via LIBLINEAR.

LIBLINEAR is the specialised cousin of LIBSVM (and developed by the same group) -- it can do less than LIBSVM, but what it can do, it can often do faster. In initial tests, using LIBLINEAR provides a small speedup. An additional advantage to LIBLINEAR is that the feature weights are returned in a more directly usable form.
