### PR TITLE
Bugfix - chance level was used as alpha level

### DIFF
--- a/ANALYSE_DECODING_ERP.m
+++ b/ANALYSE_DECODING_ERP.m
@@ -355,7 +355,7 @@ for na=1:size(ANALYSIS.RES.mean_subj_acc,1) % analysis
         if ANALYSIS.permstats == 1
             
             % chance level = 100 / number conditions
-            [H,P] = ttest(ANALYSIS.RES.all_subj_acc(:,na,step),ANALYSIS.chancelevel,ANALYSIS.chancelevel); % simply against chance
+            [H,P] = ttest(ANALYSIS.RES.all_subj_acc(:,na,step),ANALYSIS.chancelevel,ANALYSIS.pstatsuse); % simply against chance
             
         % test against permutation test results    
         elseif ANALYSIS.permstats == 2


### PR DESCRIPTION
Fixed bug in which the alpha level (critical p-value) was replaced by the chance level (100 / number of comparisons). Fixed line 358 in ANALYSE_DECODING_ERP.
