### PR TITLE
Cross categorisation bugfix

### DIFF
--- a/DECODING_ERP.m
+++ b/DECODING_ERP.m
@@ -496,7 +496,7 @@ if STUDY.avmode == 1
                         
                         delete_test_trials=fliplr(sort(test_trials));
                         
-                    elseif STUDY.cross == 1
+                    elseif STUDY.cross == 1 || STUDY.cross == 2
                         
                         % if doing cross-classification, ensure that trials
                         % from one training set don't end up in the


### PR DESCRIPTION
Included code to ensure that, when doing cross categorisation (i.e. STUDY.cross == 1 or STUDY.cross == 2), the same trials cannot end up in both the training set and the test set.
