### PR TITLE
Header formatting eeglab

### DIFF
--- a/DEMO_config_v1.m
+++ b/DEMO_config_v1.m
@@ -1,22 +1,25 @@
 function DEMO_config_v1
-%__________________________________________________________________________
-% DDTBOX script written by Stefan Bode 01/03/2013
-%
-% The toolbox was written with contributions from:
-% Daniel Bennett,  Daniel Feuerriegel, Phillip Alday
-%
-% The author further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Carsten Murawski, Carsten Bogler,
-% John-Dylan Haynes
-%__________________________________________________________________________
 %
 % This script is the configuration script for the DDTBOX. All
-% study-specific information for decoding, regression and groupl-level
+% study-specific information for decoding, regression and group-level
 % analyses are specified here.
 %
-%__________________________________________________________________________
+% Copyright (c) 2013-2016 Stefan Bode and contributors
+% 
+% This file is part of DDTBOX.
 %
-% Variable naming convention: STRUCTURE_NAME.example_variable
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 global SLIST;
 global SBJTODO;

--- a/DEMO_config_v1.m
+++ b/DEMO_config_v1.m
@@ -1,6 +1,6 @@
 function DEMO_config_v1
 %
-% This script is the configuration script for the DDTBOX. All
+% This is the configuration script for the DDTBOX. All
 % study-specific information for decoding, regression and group-level
 % analyses are specified here.
 %

--- a/analyse_decoding_erp.m
+++ b/analyse_decoding_erp.m
@@ -1,20 +1,21 @@
 function analyse_decoding_erp(study_name,vconf,input_mode,sbjs_todo,dcg_todo)
 %
-% This script is the master script for the group-level analysis of EEG decoding
+% This script is the master script for group-level analysis of EEG decoding
 % results. It will call several subscripts that run all possible analyses,
-% depending on the specific decoding analyses chosen.
+% depending on the analysis options chosen.
 %
 %
 % Inputs:
 %
-%   study_name       e.g. 'DEMO'
+%   study_name       Name corresponding to the study configuration script e.g. 'DEMO'
 %   vconf            version of study configuration script, e.g., "1" for DEMO_config_v1
-%   input_mode       1 = use coded varialbles from first section / 2 = enter manually
-%   sbjs_todo        e.g., [1 2 3 4 6 7 9 10 13]
+%   input_mode       0 = use hard-coded variables from first section / 1 = enter manually
+%   sbjs_todo        subject datasets to analyse e.g., [1 2 3 4 6 7 9 10 13]
 %   dcg_todo         discrimination group to analyse, as specified in SLIST.dcg_labels{dcg}
 %
 % Outputs:
 %  
+% Usage:            analyse_decoding_erp(study_name, vconf, input_mode, sbjs_todo, dcg_todo)
 %
 % Example:          analyse_decoding_erp('DEMO', 1, 1, [1:10], 1)
 %

--- a/analyse_decoding_erp.m
+++ b/analyse_decoding_erp.m
@@ -1,5 +1,25 @@
 function analyse_decoding_erp(study_name,vconf,input_mode,sbjs_todo,dcg_todo)
-% Copyright (c) 2013-2016, Stefan Bode and contributors 
+%
+% This script is the master script for the group-level analysis of EEG decoding
+% results. It will call several subscripts that run all possible analyses,
+% depending on the specific decoding analyses chosen.
+%
+%
+% Inputs:
+%
+%   study_name       e.g. 'DEMO'
+%   vconf            version of study configuration script, e.g., "1" for DEMO_config_v1
+%   input_mode       1 = use coded varialbles from first section / 2 = enter manually
+%   sbjs_todo        e.g., [1 2 3 4 6 7 9 10 13]
+%   dcg_todo         discrimination group to analyse, as specified in SLIST.dcg_labels{dcg}
+%
+% Outputs:
+%  
+%
+% Example:          analyse_decoding_erp('DEMO', 1, 1, [1:10], 1)
+%
+%
+% Copyright (c) 2013-2016 Stefan Bode and contributors
 % 
 % This file is part of DDTBOX.
 %
@@ -15,22 +35,6 @@ function analyse_decoding_erp(study_name,vconf,input_mode,sbjs_todo,dcg_todo)
 % 
 % You should have received a copy of the GNU General Public License
 % along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-%
-% This script is the master-script for the group-level analysis of EEG-decoding
-% results. It will call several subscripts that run all possible analyses,
-% depending on the specific decoding analyses.
-%
-% requires:
-% - study_name (e.g. 'DEMO')
-% - vconf (version of study configuration script, e.g., "1" for DEMO_config_v1)
-% - input_mode (1 = use coded varialbles from first section / 2 = enter manually)
-% - sbjs_todo (e.g., [1 2 3 4 6 7 9 10 13])
-% - dcg_todo (discrimination group to analyse, as specified in SLIST.dcg_labels{dcg})
-
-%__________________________________________________________________________
-%
-% Variable naming convention: STRUCTURE_NAME.example_variable
 
 %% GENERAL PARAMETERS AND GLOBAL VARIABLES %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %__________________________________________________________________________

--- a/analyse_feature_weights_erp.m
+++ b/analyse_feature_weights_erp.m
@@ -1,7 +1,7 @@
 function [FW_ANALYSIS] = analyse_feature_weights_erp(ANALYSIS)
 %
-% This script will analyse and plot the feature weights from the group
-% analysis.
+% This function performs group-level analyses on feature weights data and plots the results.
+% This function is called by analyse_decoding_erp.
 %
 %
 % Inputs:

--- a/analyse_feature_weights_erp.m
+++ b/analyse_feature_weights_erp.m
@@ -1,20 +1,34 @@
-function [FW_ANALYSIS]=analyse_feature_weights_erp(ANALYSIS)
-%__________________________________________________________________________
-% DDTBOX script written by Stefan Bode 01/03/2013
-%
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
-%
-% The author further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
+function [FW_ANALYSIS] = analyse_feature_weights_erp(ANALYSIS)
 %
 % This script will analyse and plot the feature weights from the group
-% analysis
-%__________________________________________________________________________
+% analysis.
 %
-% Variable naming convention: STRUCTURE_NAME.example_variable
+%
+% Inputs:
+%
+%   ANALYSIS         structure containing analysis settings and data
+%
+% Outputs:
+%
+%   FW_ANALYSIS      results of the feature weights analyses
+%
+%
+% Copyright (c) 2013-2016 Stefan Bode and contributors
+% 
+% This file is part of DDTBOX.
+%
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 %% GENERAL PARAMETERS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %__________________________________________________________________________

--- a/decoding_erp.m
+++ b/decoding_erp.m
@@ -1,7 +1,7 @@
-% decoding_erp() - Perform MVPA on a single subject 
+function [results, cfg] = decoding_erp(dat, cfg, varargin)
 %
-% Usage: 
-%		 >> [results, cfg] = decoding_erp(dat,cfg,'Key1',Value1,...);
+% Performs MVPA on a single subject 
+%
 %
 % Inputs:
 %
@@ -25,6 +25,10 @@
 % 				   'independent' parameters, e.g window_width (in samples) calculated from 
 %				   window_width_ms (in milliseconds)
 %
+%
+% Usage:           [results, cfg] = decoding_erp(dat,cfg,'Key1',Value1,...);
+%
+%
 % Copyright (c) 2013-2016, Stefan Bode and contributors 
 % 
 % This file is part of DDTBOX.
@@ -42,7 +46,6 @@
 % You should have received a copy of the GNU General Public License
 % along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-function [results, cfg] = decoding_erp(dat, cfg, varargin)
 cfg.window_width = floor(cfg.window_width_ms / ((1/cfg.srate) * 1000));
 cfg.step_width = floor(cfg.step_width_ms / ((1/cfg.srate) * 1000));
 % cross-validation defaults for single-trial decoding

--- a/decoding_erp.m
+++ b/decoding_erp.m
@@ -1,26 +1,32 @@
 function [results, cfg] = decoding_erp(dat, cfg, varargin)
 %
-% Performs MVPA on a single subject 
+% Performs MVPA on a single subject dataset.
 %
 %
 % Inputs:
 %
 %   dat            Either a file name (including path) of file containing
 %                  floating point data, or a data matrix (chans x frames)
-%   cfg			   A MATLAB struct containing the necessary configuration, 
-%				   see pop_dd_decode() for more information on necessary fields				   
+%
+%   cfg            A MATLAB struct containing the necessary configuration, 
+%                  see pop_dd_decode() for more information on necessary fields		
+%
 %  'Key1'          Keyword string for argument 1
+%
 %   Value1         Value of argument 1
+%
 %   ...            ...
 %		
 % Optional keyword inputs:
 %
-%   outdir         name of directory to write output (does not have to exist), def=pwd/ddouttmp/
+%   outdir         name of directory to write output (does not have to exist), default = pwd/ddouttmp/
+%
 %   indir          optional input directory from which to load init
 %
 % Outputs:
 %
 %   results        classification results (for use in e.g. analyse_decoding_erp())
+%
 %   cfg            updated configuration with 'dependent' parameters calculated from 
 % 				   'independent' parameters, e.g window_width (in samples) calculated from 
 %				   window_width_ms (in milliseconds)

--- a/display_group_results_erp.m
+++ b/display_group_results_erp.m
@@ -1,20 +1,31 @@
 function display_group_results_erp(ANALYSIS)
-%__________________________________________________________________________
-% DDTBOX script written by Stefan Bode 01/03/2013
-%
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
-%
-% The author further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
 %
 % This script is will plot results from the group analysis 
-
-%__________________________________________________________________________
 %
-% Variable naming convention: STRUCTURE_NAME.example_variable
+%
+% Inputs:
+%
+%   ANALYSIS        structure containing analysis settings and data
+% 
+% Outputs:
+%
+%
+% Copyright (c) 2013-2016 Stefan Bode and contributors
+% 
+% This file is part of DDTBOX.
+%
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 %% SET GLOBAL VARIABLES %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/display_group_results_erp.m
+++ b/display_group_results_erp.m
@@ -1,14 +1,13 @@
 function display_group_results_erp(ANALYSIS)
 %
-% This script is will plot results from the group analysis 
+% This script is will plot results from the group-level analyses.  
+% This function is called by analyse_decoding_erp.
 %
 %
 % Inputs:
 %
 %   ANALYSIS        structure containing analysis settings and data
 % 
-% Outputs:
-%
 %
 % Copyright (c) 2013-2016 Stefan Bode and contributors
 % 

--- a/display_indiv_results_erp.m
+++ b/display_indiv_results_erp.m
@@ -2,18 +2,17 @@ function display_indiv_results_erp(STUDY,RESULTS)
 %
 % This script gets input from decoding_erp.m and uses specified step-width 
 % and results from mutltivariate classification/regression analysis and 
-% displays individual results. If permutation test is on and display of 
+% displays individual results. If permutation tests are run and display of 
 % permutation results is on, then these results are displayed for comparison.
-%
+% This function is called by decoding_erp.
 % 
 % Inputs:
 %
 %   STUDY       structure containing participant dataset information and 
 %               multivariate classification/regression settings.
+%
 %   RESULTS     structure containing decoding results for an individual
 %               subject datset.
-%
-% Outputs:
 %
 %
 % Copyright (c) 2013-2016 Stefan Bode and contributors

--- a/display_indiv_results_erp.m
+++ b/display_indiv_results_erp.m
@@ -1,24 +1,37 @@
 function display_indiv_results_erp(STUDY,RESULTS)
-%__________________________________________________________________________
-% DDTBOX script written by Stefan Bode 01/03/2013
 %
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
+% This script gets input from decoding_erp.m and uses specified step-width 
+% and results from mutltivariate classification/regression analysis and 
+% displays individual results. If permutation test is on and display of 
+% permutation results is on, then these results are displayed for comparison.
 %
-% The author further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
+% 
+% Inputs:
 %
-% Gets input from DECODING_ERP.m
-% Uses specified step-width and results from mutltivariate classification/
-% regression analysis and displays individual results.
-% If premutation test is on and display of permutation results is on, then
-% these results are displayed for comparison.
-
-%__________________________________________________________________________
+%   STUDY       structure containing participant dataset information and 
+%               multivariate classification/regression settings.
+%   RESULTS     structure containing decoding results for an individual
+%               subject datset.
 %
-% Variable naming convention: STRUCTURE_NAME.example_variable
+% Outputs:
+%
+%
+% Copyright (c) 2013-2016 Stefan Bode and contributors
+% 
+% This file is part of DDTBOX.
+%
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 %% SET GLOBAL VARIABLES %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %__________________________________________________________________________

--- a/do_my_classification.m
+++ b/do_my_classification.m
@@ -14,8 +14,7 @@ function [acc,feat_weights] = do_my_classification(vectors_train,labels_train,ve
 %   labels_train    condition labels for the training dataset
 %   vectors_test    data vectors that make up the test dataset
 %   labels_test     condition labels for the test dataset
-%   STUDY           structure containing participant dataset information and 
-%                   multivariate classification/regression settings.
+%   STUDY           structure containing multivariate classification/regression settings
 % 
 %
 % Outputs:

--- a/do_my_classification.m
+++ b/do_my_classification.m
@@ -1,23 +1,46 @@
 function [acc,feat_weights] = do_my_classification(vectors_train,labels_train,vectors_test,labels_test,STUDY)
-%__________________________________________________________________________
-% DDTBOX script written by Stefan Bode 01/03/2013
 %
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
-%
-% The author further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
+% Performs multivariate pattern classification/regression using input
+% vectors of training/test data and condition labels. 
 %
 % This script interacts with LIBSVM toolbox (Chang & Lin) to do the classfication / regression
 % see: https://www.csie.ntu.edu.tw/~cjlin/libsvm/
 % Chang CC, Lin CJ (2011). LIBSVM : a library for support vector machines. ACM TIST, 2(3):27,
 %
+% 
+% Inputs:
 %
-%__________________________________________________________________________
+%   vectors_train   data vectors that make up the training dataset
+%   labels_train    condition labels for the training dataset
+%   vectors_test    data vectors that make up the test dataset
+%   labels_test     condition labels for the test dataset
+%   STUDY           structure containing participant dataset information and 
+%                   multivariate classification/regression settings.
+% 
 %
-% Variable naming convention: STRUCTURE_NAME.example_variable
+% Outputs:
+%
+%   acc             classifier accuracy for classification of the test dataset.
+%   feat_weights    feature weights from the multivariate pattern
+%                   classification.
+%
+%
+% Copyright (c) 2013-2016 Stefan Bode and contributors
+% 
+% This file is part of DDTBOX.
+%
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 %% define samples and labels for training
 

--- a/do_my_classification.m
+++ b/do_my_classification.m
@@ -2,6 +2,7 @@ function [acc,feat_weights] = do_my_classification(vectors_train,labels_train,ve
 %
 % Performs multivariate pattern classification/regression using input
 % vectors of training/test data and condition labels. 
+% This function is called by prepare_my_vectors_erp.
 %
 % This script interacts with LIBSVM toolbox (Chang & Lin) to do the classfication / regression
 % see: https://www.csie.ntu.edu.tw/~cjlin/libsvm/
@@ -11,17 +12,21 @@ function [acc,feat_weights] = do_my_classification(vectors_train,labels_train,ve
 % Inputs:
 %
 %   vectors_train   data vectors that make up the training dataset
+%
 %   labels_train    condition labels for the training dataset
+%
 %   vectors_test    data vectors that make up the test dataset
+%
 %   labels_test     condition labels for the test dataset
+%
 %   STUDY           structure containing multivariate classification/regression settings
 % 
 %
 % Outputs:
 %
-%   acc             classifier accuracy for classification of the test dataset.
-%   feat_weights    feature weights from the multivariate pattern
-%                   classification.
+%   acc             classifier accuracy for classification of the test data
+%
+%   feat_weights    feature weights from the classifier
 %
 %
 % Copyright (c) 2013-2016 Stefan Bode and contributors

--- a/eeglab_example_header.m
+++ b/eeglab_example_header.m
@@ -1,0 +1,35 @@
+function eeglab_example_header(EEG, varargin)
+%
+% This script copies the channel location information from a loaded EEGLab
+% dataset and uses this data to create a channel locations file. The channel locations file
+% is then saved at the specified location. An EEGLab dataset must be loaded 
+% first for this script to work.
+%
+%
+% Required Inputs:
+% - EEG (EEGLab data structure)
+% 
+% Optional Inputs:
+% - save_filepath (location in which to save the chanlocs file) 
+%
+% Outputs:
+% 
+% Example:
+%
+%
+% Copyright (c) 2016 _________ and contributors
+% 
+% This file is part of DDTBOX.
+%
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/make_chanlocs_file.m
+++ b/make_chanlocs_file.m
@@ -2,19 +2,25 @@ function make_chanlocs_file(EEG, varargin)
 %
 % This script copies the channel location information from a loaded EEGLab
 % dataset and uses this data to create a channel locations file. The channel locations file
-% is then saved at the specified location. An EEGLab dataset must be loaded 
-% first for this script to work.
+% is then saved at the specified location (does not have to exist). An EEGLab dataset must be loaded 
+% for this function to work.
 %
 % Inputs:
 %
-%   EEG             EEGLab data structure
+%   EEG            EEGLab data structure
+%
+%  'Key1'          Keyword string for argument 1
+%
+%   Value1         Value of argument 1
 % 
-% optional:
-%   save_filepath 	location in which to save the channel locations file 
+% Optional Keyword Inputs:
+%
+%   save_filepath 	location in which to save the channel locations file, including file name. Default = pwd/ddchanlocstmp/chanlocs.mat 
 %
 % Outputs:
 %
-% Example:          make_chanlocs_file(EEG, 'Channel Locations/chanlocs_for_DDTBox.mat');
+%
+% Example:          make_chanlocs_file(EEG, 'save_filepath', 'Channel Locations/chanlocs_for_DDTBox.mat');
 %
 %
 % Copyright (c) 2016 Daniel Feuerriegel and contributors
@@ -37,7 +43,7 @@ function make_chanlocs_file(EEG, varargin)
 %% Handling variadic inputs
 % Define defaults at the beginning
 options = struct(...
-    'save_filepath', []);
+    'save_filepath', [pwd '/ddchanlocstmp/chanlocs.mat']);
 
 % Read the acceptable names
 option_names = fieldnames(options);

--- a/make_chanlocs_file.m
+++ b/make_chanlocs_file.m
@@ -5,11 +5,16 @@ function make_chanlocs_file(EEG, varargin)
 % is then saved at the specified location. An EEGLab dataset must be loaded 
 % first for this script to work.
 %
-% required:
-% - EEG (EEGLab data structure)
+% Inputs:
+%
+%   EEG             EEGLab data structure
 % 
 % optional:
-% - save_filepath (location in which to save the chanlocs file) 
+%   save_filepath 	location in which to save the channel locations file 
+%
+% Outputs:
+%
+% Example:          make_chanlocs_file(EEG, 'Channel Locations/chanlocs_for_DDTBox.mat');
 %
 %
 % Copyright (c) 2016 Daniel Feuerriegel and contributors

--- a/multcomp_blaire_karniski_permtest.m
+++ b/multcomp_blaire_karniski_permtest.m
@@ -14,9 +14,21 @@ function [corrected_h, corrected_p, critical_t] = multcomp_blaire_karniski_permt
 % Inputs:
 %
 %   cond1_data      data from condition 1, a subjects x time windows matrix
+%
 %   cond2_data      data from condition 2, a subjects x time windows matrix
+%
+%
+%  'Key1'          Keyword string for argument 1
+%
+%   Value1         Value of argument 1
+%
+%   ...            ...
+%
+% Optional Keyword Inputs:
+%
 %   alpha           uncorrected alpha level for statistical significance, 
 %                   default is 0.05
+%
 %   iterations      number of permutation samples to draw. Default is 5000
 %                   At least 1000 is recommended for the p = 0.05 alpha 
 %                   level, and at least 5000 is recommended for the 
@@ -37,7 +49,7 @@ function [corrected_h, corrected_p, critical_t] = multcomp_blaire_karniski_permt
 %                   percentile then p < .01.
 %
 %   critical_t      absolute critical t-value. t-values larger than this are
-%                   counted as statistically significant
+%                   counted as statistically significant.
 %
 % Example:          [corrected_h, corrected_p, critical_t] = multcomp_blaire_karniski_permtest(cond1_data, cond2_data, 'alpha', '0.05', 'iterations', 10000) 
 %

--- a/multcomp_blaire_karniski_permtest.m
+++ b/multcomp_blaire_karniski_permtest.m
@@ -1,56 +1,63 @@
 function [corrected_h, corrected_p, critical_t] = multcomp_blaire_karniski_permtest(cond1_data, cond2_data, varargin)
-
-%__________________________________________________________________________
-% Multiple comparisons correction function written by Daniel Feuerriegel 21/04/2016 
-% to complement DDTBOX scripts written by Stefan Bode 01/03/2013.
 %
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
-%
-% The author (Stefan Bode) further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
-%
-% This script receives the original data and outputs corrected p-values and
+% This script receives paired-samples data and outputs corrected p-values and
 % hypothesis test results based on a maximum statistic permutation test
 % (Blaire & Karniski, 1993). The permutation test in this script is based
-% on the t-statistic, but could be adapted to use with other statistics
-% such as the trimmed mean.
+% on the t-statistic from a paired-samples t-test, but could be adapted 
+% to use with other statistics such as the trimmed mean or yuen's t.
 %
 % Blair, R. C., & Karniski, W. (1993). An alternative method for 
 % significance testing of waveform difference potentials. 
 % Psychophysiology, 30, 518-524. DOI: 10.1111/j.1469-8986.1993.tb02075.x
 %
-% requires:
-% - cond1_data (data from condition 1, a subjects x time windows matrix)
-% - cond2_data (data from condition 2, a subjects x time windows matrix)
+%
+% Inputs:
+%
+%   cond1_data      data from condition 1, a subjects x time windows matrix
+%   cond2_data      data from condition 2, a subjects x time windows matrix
+%   alpha           uncorrected alpha level for statistical significance, 
+%                   default is 0.05
+%   iterations      number of permutation samples to draw. Default is 5000
+%                   At least 1000 is recommended for the p = 0.05 alpha 
+%                   level, and at least 5000 is recommended for the 
+%                   p = 0.01 alpha level. This is due to extreme events
+%                   at the tails of the permutation distribution being very 
+%                   rare, needing many random permutations to accurately estimate them.
+%
+% Outputs:
+%
+%   corrected_h     vector of hypothesis tests in which statistical significance
+%                   is defined by values above a threshold of the 
+%                   (alpha_level * 100)th percentile of the maximum statistic distribution.
+%                   1 = statistically significant, 0 = not statistically significant
+%
+%   corrected_p     vector of p-values derived from assessing the t-value of
+%                   each test relative to the distribution of maximum t-values across
+%                   iterations in the permutation test. For example, if above the 99th
+%                   percentile then p < .01.
+%
+%   critical_t      absolute critical t-value. t-values larger than this are
+%                   counted as statistically significant
+%
+% Example:          [corrected_h, corrected_p, critical_t] = multcomp_blaire_karniski_permtest(cond1_data, cond2_data, 'alpha', '0.05', 'iterations', 10000) 
+%
+%
+% Copyright (c) 2016 Daniel Feuerriegel and contributors
 % 
-% optional inputs:
-% - alpha (uncorrected alpha level for statistical significance, default is 0.05)
-% - iterations (number of permutation samples to draw. Default is 5000.
-% At least 1000 is recommended for the p = 0.05 alpha level, and at least 5000 is
-% recommended for the p = 0.01 alpha level. This is due to extreme events
-% at the tails being very rare, needing many random permutations to find
-% enough of them).
+% This file is part of DDTBOX.
 %
-%
-% outputs:
-% - corrected_h (vector of hypothesis tests in which statistical significance
-% is defined by values above a threshold of the (alpha_level * 100)th percentile
-% of the maximum statistic distribution.
-% 1 = statistically significant, 0 = not statistically significant)
-%
-% - corrected_p (vector of p-values derived from assessing the t-value of
-% each test relative to the distribution of maximum t-values across
-% iterations in the permutation test. For example, if above the 99th
-% percentile then p < .01.
-%
-% - critical_t (absolute critical t-value. t-values higher than this are
-% counted as statistically significant).
-%__________________________________________________________________________
-%
-% Variable naming convention: STRUCTURE_NAME.example_variable
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 %% Handling variadic inputs
 % Define defaults at the beginning

--- a/multcomp_bonferroni.m
+++ b/multcomp_bonferroni.m
@@ -1,18 +1,6 @@
 function [bonferroni_corrected_h, bonferroni_corrected_alpha] = multcomp_bonferroni(p_values, varargin)
-
-%__________________________________________________________________________
-% Multiple comparisons correction function written by Daniel Feuerriegel 21/04/2016 
-% to complement DDTBOX scripts written by Stefan Bode 01/03/2013.
 %
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
-%
-% The author (Stefan Bode) further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
-%
-% This script receives a vector of p-values and outputs
+% This function receives a vector of p-values and outputs
 % Bonferroni-corrected null hypothesis test results. The number of tests is
 % determined by the length of the vector of p-values.
 %
@@ -24,22 +12,45 @@ function [bonferroni_corrected_h, bonferroni_corrected_alpha] = multcomp_bonferr
 % American Statistical Association, 56(293), 52-64. doi 10.1080/01621459.1961.10482090
 %
 %
-% requires:
-% - p_values (vector of p-values from the hypothesis tests of interest)
+% Inputs:
+%
+%   p_values    vector of p-values from the hypothesis tests of interest
 % 
-% optional:
-% - alpha (uncorrected alpha level for statistical significance, default 0.05)
+%   alpha       uncorrected alpha level for statistical significance, default 0.05
 %
 %
-% outputs:
-% - bonferroni_corrected_h (vector of Bonferroni-corrected hypothesis tests 
-% derived from comparing p-values to Bonferroni adjusted critical alpha level. 
-% 1 = statistically significant, 0 = not statistically significant)
+% Outputs:
 %
-% - bonferroni_corrected_alpha (the corrected critical alpha level)
-%__________________________________________________________________________
+%   bonferroni_corrected_h      vector of Bonferroni-corrected hypothesis tests 
+%                               derived from comparing p-values to Bonferroni 
+%                               adjusted critical alpha level. 
+%                               1 = statistically significant, 
+%                               0 = not statistically significant
 %
-% Variable naming convention: STRUCTURE_NAME.example_variable
+%   bonferroni_corrected_alpha      adjusted alpha level. p-values below
+%                                   threshold are declared statistically
+%                                   significant.
+%
+%
+% Example:      [bonferroni_corrected_h, bonferroni_corrected_alpha] = multcomp_bonferroni(p_values, 'alpha', 0.01)          
+%
+%
+% Copyright (c) 2016 Daniel Feuerriegel and contributors
+% 
+% This file is part of DDTBOX.
+%
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 %% Handling variadic inputs
 % Define defaults at the beginning

--- a/multcomp_bonferroni.m
+++ b/multcomp_bonferroni.m
@@ -1,8 +1,9 @@
 function [bonferroni_corrected_h, bonferroni_corrected_alpha] = multcomp_bonferroni(p_values, varargin)
 %
 % This function receives a vector of p-values and outputs
-% Bonferroni-corrected null hypothesis test results. The number of tests is
-% determined by the length of the vector of p-values.
+% Bonferroni-corrected results. The number of tests is
+% determined by the length of the vector of p-values. Note that
+% The alpha level is adjusted rather than the p-values.
 %
 %
 % Dunn, O. J. (1959). Estimation of the medians for dependent variables. 
@@ -16,6 +17,12 @@ function [bonferroni_corrected_h, bonferroni_corrected_alpha] = multcomp_bonferr
 %
 %   p_values    vector of p-values from the hypothesis tests of interest
 % 
+%  'Key1'          Keyword string for argument 1
+%
+%   Value1         Value of argument 1
+% 
+% Optional Keyword Inputs:
+%
 %   alpha       uncorrected alpha level for statistical significance, default 0.05
 %
 %

--- a/multcomp_cluster_permtest.m
+++ b/multcomp_cluster_permtest.m
@@ -1,21 +1,10 @@
 function [corrected_h] = multcomp_cluster_permtest(cond1_data, cond2_data, varargin)
-
-%__________________________________________________________________________
-% Multiple comparisons correction function written by Daniel Feuerriegel 21/04/2016 
-% to complement DDTBOX scripts written by Stefan Bode 01/03/2013.
 %
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
-%
-% The author (Stefan Bode) further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
-%
-% This script receives the original data and outputs corrected p-values and
-% hypothesis test results based on a maximum cluster statistic permutation test.
-% The permutation test in this script is based on the t-statistic, 
-% but could be adapted to use with other statistics such as the trimmed mean.
+% This function receives the original data and outputs corrected p-values and
+% hypothesis test results based on a maximum cluster statistic permutation test,
+% as described in Bullmore et al. (1999). The permutation test in this function
+% is based on the t-statistic but could be adapted to use with other 
+% statistics such as the trimmed mean.
 %
 % 
 % Bullmore, E. T., Suckling, J., Overmeyer, S., Rabe-Hesketh, S., 
@@ -24,32 +13,47 @@ function [corrected_h] = multcomp_cluster_permtest(cond1_data, cond2_data, varar
 % structural MR images of the brain. IEEE Transactions on Medical Imaging,
 % 18, 32-42. doi 10.1109/42.750253
 %
-% requires:
-% - cond1_data (data from condition 1, a subjects x time windows matrix)
-% - cond2_data (data from condition 2, a subjects x time windows matrix)
+% Inputs:
 %
-% optional:
-% - alpha (uncorrected alpha level for statistical significance, default 0.05)
-% - iterations (number of permutation samples to draw. At least 1000 is
-% recommended for the p = 0.05 alpha level, and at least 5000 is
-% recommended for the p = 0.01 alpha level. This is due to extreme events
-% at the tails being very rare, needing many random permutations to find
-% enough of them).
-% - clusteringalpha (the significance threshold used to define
-% individual points within a cluster. Setting this to larger values (e.g.
-% 0.05) will detect broadly distributed clusters, whereas setting it to
-% 0.01 will help detect smaller clusters that exhibit strong effects.
+%   cond1_data      data from condition 1, a subjects x time windows matrix
+%   cond2_data      data from condition 2, a subjects x time windows matrix
+%   alpha           uncorrected alpha level for statistical significance, default 0.05
+%   iterations      number of permutation samples to draw. At least 1000 is
+%                   recommended for the p = 0.05 alpha level, and at least 5000 is
+%                   recommended for the p = 0.01 alpha level. This is due to extreme events
+%                   at the tails being very rare, needing many random permutations to find
+%                   enough of them.
+%   clusteringalpha the significance threshold used to define individual points 
+%                   within a cluster. Setting this to larger values (e.g.
+%                   0.05) will detect broadly distributed clusters, whereas setting it to
+%                   0.01 will help detect smaller clusters that exhibit strong effects.
 %
-% outputs:
-% corrected_h (vector of hypothesis tests in which statistical significance
-% is defined by values above a threshold of the (alpha_level * 100)th percentile
-% of the maximum statistic distribution.
-% 1 = statistically significant, 0 = not statistically significant)
-%__________________________________________________________________________
+% Outputs:
 %
-% Variable naming convention: STRUCTURE_NAME.example_variable
-
-% alpha_level, n_iterations, clustering_alpha
+%   corrected_h     vector of hypothesis tests in which statistical significance
+%                   is defined by values above a threshold of the (alpha_level * 100)th
+%                   percentile of the maximum statistic distribution.
+%                   1 = statistically significant, 0 = not statistically significant
+%
+% Example:          [corrected_h] = multcomp_cluster_permtest(cond1_data, cond2_data, 'alpha', 0.05, 'iterations', 10000, 'clusteringalpha', 0.01)
+%
+%
+% Copyright (c) 2016 Daniel Feuerriegel and contributors
+% 
+% This file is part of DDTBOX.
+%
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 %% Handling variadic inputs
 % Define defaults at the beginning

--- a/multcomp_cluster_permtest.m
+++ b/multcomp_cluster_permtest.m
@@ -4,7 +4,7 @@ function [corrected_h] = multcomp_cluster_permtest(cond1_data, cond2_data, varar
 % hypothesis test results based on a maximum cluster statistic permutation test,
 % as described in Bullmore et al. (1999). The permutation test in this function
 % is based on the t-statistic but could be adapted to use with other 
-% statistics such as the trimmed mean.
+% statistics such as the trimmed mean or Yuen's t.
 %
 % 
 % Bullmore, E. T., Suckling, J., Overmeyer, S., Rabe-Hesketh, S., 
@@ -16,17 +16,29 @@ function [corrected_h] = multcomp_cluster_permtest(cond1_data, cond2_data, varar
 % Inputs:
 %
 %   cond1_data      data from condition 1, a subjects x time windows matrix
+%
 %   cond2_data      data from condition 2, a subjects x time windows matrix
+%
+%  'Key1'          Keyword string for argument 1
+%
+%   Value1         Value of argument 1
+%
+%   ...            ...
+%
+% Optional Keyword Inputs
+%
 %   alpha           uncorrected alpha level for statistical significance, default 0.05
+%
 %   iterations      number of permutation samples to draw. At least 1000 is
 %                   recommended for the p = 0.05 alpha level, and at least 5000 is
 %                   recommended for the p = 0.01 alpha level. This is due to extreme events
 %                   at the tails being very rare, needing many random permutations to find
 %                   enough of them.
+%
 %   clusteringalpha the significance threshold used to define individual points 
 %                   within a cluster. Setting this to larger values (e.g.
 %                   0.05) will detect broadly distributed clusters, whereas setting it to
-%                   0.01 will help detect smaller clusters that exhibit strong effects.
+%                   0.01 for example will help detect smaller clusters that exhibit strong effects.
 %
 % Outputs:
 %

--- a/multcomp_fdr_bh.m
+++ b/multcomp_fdr_bh.m
@@ -1,18 +1,6 @@
 function [fdr_corrected_h, benhoch_critical_alpha] = multcomp_fdr_bh(p_values, varargin)
-
-%__________________________________________________________________________
-% Multiple comparisons correction function written by Daniel Feuerriegel 21/04/2016 
-% to complement DDTBOX scripts written by Stefan Bode 01/03/2013.
 %
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
-%
-% The author (Stefan Bode) further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
-%
-% This script receives a vector of p-values and outputs
+% This function receives a vector of p-values and outputs
 % false discovery rate corrected null hypothesis test results (Benjamin-Hochberg procedure).
 % The number of tests is determined by the length of the vector of p-values.
 %
@@ -22,25 +10,43 @@ function [fdr_corrected_h, benhoch_critical_alpha] = multcomp_fdr_bh(p_values, v
 % Stable link:http://www.jstor.org/stable/2346101 
 %
 %
-% requires:
-% - p_values (vector of p-values from the hypothesis tests of interest)
+% Inputs:
 %
-% optional:
-% - alpha (uncorrected alpha level for statistical significance, default 0.05)
+%   p_values            vector of p-values from the hypothesis tests of interest
+%   alpha               uncorrected alpha level for statistical significance, default 0.05
+%
+% Outputs:
+%
+%   fdr_corrected_h     vector of false discovery rate corrected hypothesis tests 
+%                       derived from comparing p-values to false discovery rate 
+%                       adjusted critical alpha level. 
+%                       1 = statistically significant, 0 = not statistically significant
+%
+%   benhoch_critical_alpha      the adjusted critical alpha for the false
+%                               discovery rate procedure. p-values smaller
+%                               or equal to this value are declared
+%                               statistically significant. This value is 0 
+%                               if no tests were statistically significant.
+%
+% Example:              [fdr_corrected_h, benhoch_critical_alpha] = multcomp_fdr_bh(p_values, 'alpha', 0.05)
 %
 %
-% outputs:
-% - fdr_corrected_h (vector of false discovery rate corrected hypothesis tests 
-% derived from comparing p-values to false discovery rate adjusted critical alpha level. 
-% 1 = statistically significant, 0 = not statistically significant)
+% Copyright (c) 2016 Daniel Feuerriegel and contributors
+% 
+% This file is part of DDTBOX.
 %
-% - benhoch_critical_alpha (the adjusted critical alpha for the false
-% discovery rate procedure. p-values smaller or equal to this value are
-% declared statistically significant. This value is 0 if no tests reached 
-% statistical significance).
-%__________________________________________________________________________
-%
-% Variable naming convention: STRUCTURE_NAME.example_variable
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 %% Handling variadic inputs
 % Define defaults at the beginning

--- a/multcomp_fdr_bh.m
+++ b/multcomp_fdr_bh.m
@@ -13,6 +13,13 @@ function [fdr_corrected_h, benhoch_critical_alpha] = multcomp_fdr_bh(p_values, v
 % Inputs:
 %
 %   p_values            vector of p-values from the hypothesis tests of interest
+%
+%  'Key1'          Keyword string for argument 1
+%
+%   Value1         Value of argument 1
+%
+% Optional Keyword Inputs:
+%
 %   alpha               uncorrected alpha level for statistical significance, default 0.05
 %
 % Outputs:
@@ -27,6 +34,7 @@ function [fdr_corrected_h, benhoch_critical_alpha] = multcomp_fdr_bh(p_values, v
 %                               or equal to this value are declared
 %                               statistically significant. This value is 0 
 %                               if no tests were statistically significant.
+%
 %
 % Example:              [fdr_corrected_h, benhoch_critical_alpha] = multcomp_fdr_bh(p_values, 'alpha', 0.05)
 %

--- a/multcomp_fdr_bky.m
+++ b/multcomp_fdr_bky.m
@@ -1,43 +1,49 @@
 function [fdr_corrected_h, bky_stage2_critical_alpha] = multcomp_fdr_bky(p_values, varargin)
-
-%__________________________________________________________________________
-% Multiple comparisons correction function written by Daniel Feuerriegel 21/04/2016 
-% to complement DDTBOX scripts written by Stefan Bode 01/03/2013.
 %
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
-%
-% The author (Stefan Bode) further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
-%
-% This script receives a vector of p-values and outputs
-% false discovery rate corrected null hypothesis test results (Benjamin-Krieger-Yekutieli procedure).
-% The number of tests is determined by the length of the vector of p-values.
+% This function receives a vector of p-values and outputs
+% false discovery rate corrected null hypothesis test results 
+% (Benjamin-Krieger-Yekutieli procedure). The number of tests is 
+% determined by the length of the vector of p-values.
 %
 % Benjamini, Y., Krieger, A. M., & Yekutieli, D. (2006). Adapting linear step-up
 % procedures that control the false discovery rate. Biometrika, 93, 491-507.
 % doi 10.1093/biomet/93.3.491
 %
 %
-% requires:
-% - p_values (vector of p-values from the hypothesis tests of interest)
+% Inputs:
+%   p_values        vector of p-values from the hypothesis tests of interest
+%   alpha           uncorrected alpha level for statistical significance, 
+%                   default 0.05
+%
+% Outputs:
+%
+%   fdr_corrected_h     vector of false discovery rate corrected hypothesis tests 
+%                       derived from comparing p-values to false discovery rate 
+%                       adjusted critical alpha level. 
+%                       1 = statistically significant, 0 = not statistically significant
+%
+%   bky_stage2_critical_alpha       adjusted alpha level. p-values smaller or
+%                                   equal to this are declared statistically-significant
+%
+% Example:              [fdr_corrected_h, bky_stage2_critical_alpha] = multcomp_fdr_bky(p_values, 'alpha', 0.05)
+%
+%
+% Copyright (c) 2016 Daniel Feuerriegel and contributors
 % 
-% optional:
-% - alpha (uncorrected alpha level for statistical significance, default 0.05)
+% This file is part of DDTBOX.
 %
-%
-% outputs:
-% - fdr_corrected_h (vector of false discovery rate corrected hypothesis tests 
-% derived from comparing p-values to false discovery rate adjusted critical alpha level. 
-% 1 = statistically significant, 0 = not statistically significant)
-%
-% - bky_stage2_critical_alpha (adjusted alpha level. p-values smaller or
-% equal to this are declared statistically-significant).
-%__________________________________________________________________________
-%
-% Variable naming convention: STRUCTURE_NAME.example_variable
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 %% Handling variadic inputs
 % Define defaults at the beginning

--- a/multcomp_fdr_bky.m
+++ b/multcomp_fdr_bky.m
@@ -12,6 +12,13 @@ function [fdr_corrected_h, bky_stage2_critical_alpha] = multcomp_fdr_bky(p_value
 %
 % Inputs:
 %   p_values        vector of p-values from the hypothesis tests of interest
+%
+%  'Key1'          Keyword string for argument 1
+%
+%   Value1         Value of argument 1
+% 
+% Optional Keyword Inputs:
+%
 %   alpha           uncorrected alpha level for statistical significance, 
 %                   default 0.05
 %

--- a/multcomp_fdr_by.m
+++ b/multcomp_fdr_by.m
@@ -1,19 +1,8 @@
 function [fdr_corrected_h, benyek_critical_alpha] = multcomp_fdr_by(p_values, varargin)
-
-%__________________________________________________________________________
-% Multiple comparisons correction function written by Daniel Feuerriegel 21/04/2016 
-% to complement DDTBOX scripts written by Stefan Bode 01/03/2013.
 %
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
 %
-% The author (Stefan Bode) further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
-%
-% This script receives a vector of p-values and outputs
-% false discovery rate corrected null hypothesis test results (Benjamin-Yekutieli procedure).
+% This function receives a vector of p-values and outputs false discovery rate 
+% corrected null hypothesis test results (Benjamin-Yekutieli procedure).
 % The number of tests is determined by the length of the vector of p-values.
 %
 % Benjamini, Y., & Yekutieli, D. (2001). The control of the false discovery 
@@ -21,25 +10,43 @@ function [fdr_corrected_h, benyek_critical_alpha] = multcomp_fdr_by(p_values, va
 % doi 10.1093/biomet/93.3.491
 %
 %
-% requires:
-% - p_values (vector of p-values from the hypothesis tests of interest)
+% Inputs:
 %
-% optional:
-% - alpha (uncorrected alpha level for statistical significance, default 0.05)
+%   p_values    vector of p-values from the hypothesis tests of interest
+%   alpha       uncorrected alpha level for statistical significance, default 0.05
+%
+% Outputs:
+%
+%   fdr_corrected_h     vector of false discovery rate corrected hypothesis 
+%                       tests derived from comparing p-values to false 
+%                       discovery rate adjusted critical alpha level. 
+%                       1 = statistically significant, 0 = not statistically significant
+%
+%   benyek_critical_alpha       the adjusted critical alpha for the false
+%                               discovery rate procedure. p-values smaller 
+%                               or equal to this value are declared 
+%                               statistically significant. This value is 0 
+%                               if no tests were statistically significant.
+%
+% Example:              [fdr_corrected_h, benyek_critical_alpha] = multcomp_fdr_by(p_values, 'alpha', 0.05)
 %
 %
-% outputs:
-% - fdr_corrected_h (vector of false discovery rate corrected hypothesis tests 
-% derived from comparing p-values to false discovery rate adjusted critical alpha level. 
-% 1 = statistically significant, 0 = not statistically significant)
+% Copyright (c) 2016 Daniel Feuerriegel and contributors
+% 
+% This file is part of DDTBOX.
 %
-% - benyek_critical_alpha (the adjusted critical alpha for the false
-% discovery rate procedure. p-values smaller or equal to this value are
-% declared statistically significant. This value is 0 if no tests reached 
-% statistical significance).
-%__________________________________________________________________________
-%
-% Variable naming convention: STRUCTURE_NAME.example_variable
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 %% Handling variadic inputs
 % Define defaults at the beginning

--- a/multcomp_fdr_by.m
+++ b/multcomp_fdr_by.m
@@ -13,6 +13,13 @@ function [fdr_corrected_h, benyek_critical_alpha] = multcomp_fdr_by(p_values, va
 % Inputs:
 %
 %   p_values    vector of p-values from the hypothesis tests of interest
+%
+%  'Key1'          Keyword string for argument 1
+%
+%   Value1         Value of argument 1
+%
+% Optional Keyword Inputs:
+%
 %   alpha       uncorrected alpha level for statistical significance, default 0.05
 %
 % Outputs:

--- a/multcomp_holm_bonferroni.m
+++ b/multcomp_holm_bonferroni.m
@@ -1,15 +1,22 @@
 function [holm_corrected_h, holm_corrected_alpha] = multcomp_holm_bonferroni(p_values, varargin)
 %
 % This function receives a vector of p-values and outputs
-% Holm-Bonferroni corrected null hypothesis test results. The number of tests is
+% Holm-Bonferroni corrected results. The number of tests is
 % determined by the length of the vector of p-values.
 %
 % Holm, S. (1979). A simple sequentially rejective multiple test procedure. 
-% Scandinavian Journal of Statistics 6 (2): 65?70.
+% Scandinavian Journal of Statistics 6 (2): 65-70.
 %
 % Inputs:
 %
 %   p_values        vector of p-values from the hypothesis tests of interest
+%
+%  'Key1'          Keyword string for argument 1
+%
+%   Value1         Value of argument 1
+%
+% Optional Keyword Inputs:
+%
 %   alpha           uncorrected alpha level for statistical significance, 
 %                   default 0.05
 %

--- a/multcomp_holm_bonferroni.m
+++ b/multcomp_holm_bonferroni.m
@@ -1,40 +1,46 @@
 function [holm_corrected_h, holm_corrected_alpha] = multcomp_holm_bonferroni(p_values, varargin)
-
-%__________________________________________________________________________
-% Multiple comparisons correction function written by Daniel Feuerriegel 21/04/2016 
-% to complement DDTBOX scripts written by Stefan Bode 01/03/2013.
 %
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
-%
-% The author (Stefan Bode) further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
-%
-% This script receives a vector of p-values and outputs
+% This function receives a vector of p-values and outputs
 % Holm-Bonferroni corrected null hypothesis test results. The number of tests is
 % determined by the length of the vector of p-values.
 %
 % Holm, S. (1979). A simple sequentially rejective multiple test procedure. 
 % Scandinavian Journal of Statistics 6 (2): 65?70.
 %
-% requires:
-% - p_values (vector of p-values from the hypothesis tests of interest)
+% Inputs:
 %
-% optional:
-% - alpha_level (uncorrected alpha level for statistical significance, default 0.05)
+%   p_values        vector of p-values from the hypothesis tests of interest
+%   alpha           uncorrected alpha level for statistical significance, 
+%                   default 0.05
+%
+% Outputs:
+%
+%   holm_corrected_h    vector of Holm-Bonferroni corrected hypothesis tests 
+%                       derived from comparing p-values to Holm-Bonferroni 
+%                       adjusted critical alpha level. 
+%                       1 = statistically significant, 0 = not statistically significant
+%
+%   holm_corrected_alpha        the Holm-Bonferroni adjusted alpha level
+%
+% Example:            [holm_corrected_h, holm_corrected_alpha] = multcomp_holm_bonferroni(p_values, 'alpha', 0.05)  
 %
 %
-% outputs:
-% - holm_corrected_h (vector of Holm-Bonferroni corrected hypothesis tests 
-% derived from comparing p-values to Holm-Bonferroni adjusted critical alpha level. 
-% 1 = statistically significant, 0 = not statistically significant)
+% Copyright (c) 2016 Daniel Feuerriegel and contributors
+% 
+% This file is part of DDTBOX.
 %
-% - holm_corrected_alpha (the adjusted alpha threshold)
-%__________________________________________________________________________
-%
-% Variable naming convention: STRUCTURE_NAME.example_variable
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 %% Handling variadic inputs
 % Define defaults at the beginning

--- a/multcomp_ktms.m
+++ b/multcomp_ktms.m
@@ -1,20 +1,8 @@
 function [corrected_h] = multcomp_ktms(cond1_data, cond2_data, varargin)
-
-%__________________________________________________________________________
-% Multiple comparisons correction function written by Daniel Feuerriegel 21/04/2016 
-% to complement DDTBOX scripts written by Stefan Bode 01/03/2013.
 %
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
-%
-% The author (Stefan Bode) further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
-%
-% This script receives the original data and outputs corrected p-values and
+% This function receives the original data and outputs corrected p-values and
 % hypothesis test results based on control of the generalised family-wise error rate
-% (Korn, 2004, method A in appendices). The permutation test in this script is based
+% (Korn, 2004, method A in their appendices). The permutation test in this script is based
 % on the t-statistic, but could be adapted to use with other statistics
 % such as the trimmed mean.
 %
@@ -24,30 +12,48 @@ function [corrected_h] = multcomp_ktms(cond1_data, cond2_data, varargin)
 % doi 10.1016/S0378-3758(03)00211-8
 %
 %
-% requires:
-% - cond1_data (data from condition 1, a subjects x time windows matrix)
-% - cond2_data (data from condition 2, a subjects x time windows matrix)
+% Inputs:
 %
-% optional:
-% - alpha (uncorrected alpha level for statistical significance, default 0.05)
-% - iterations (number of permutation samples to draw, default 5000. 
-% At least 1000 is recommended for the p = 0.05 alpha level, and at least 5000 is
-% recommended for the p = 0.01 alpha level. This is due to extreme events
-% at the tails being very rare, needing many random permutations to find
-% enough of them).
-% - ktms_u (the u parameter of the procedure, or the number of hypotheses
-% to automatically reject. Allowing for more false discoveries improves the
-% sensitivity of the method. Default is 1).
+%   cond1_data      data from condition 1, a subjects x time windows matrix
+%   cond2_data      data from condition 2, a subjects x time windows matrix
+%   alpha           uncorrected alpha level for statistical significance, 
+%                   default 0.05
+%   iterations      number of permutation samples to draw, default 5000. 
+%                   At least 1000 is recommended for the p = 0.05 alpha level, 
+%                   and at least 5000 is recommended for the p = 0.01 alpha level.
+%                   This is due to extreme events at the tails being very rare, 
+%                   needing many random permutations to find enough of them.
+%   ktms_u          the u parameter of the procedure, or the number of hypotheses
+%                   to automatically reject. Allowing for more false discoveries
+%                   improves the sensitivity of the method to find real effects. 
+%                   Default is 1.
+%
+% Outputs:
+%
+%   corrected_h     vector of hypothesis tests in which statistical significance
+%                   is defined by values above a threshold of the (alpha_level * 100)th
+%                   percentile of the maximum statistic distribution.
+%                   1 = statistically significant, 0 = not statistically significant
+%
+% Example:          [corrected_h] = multcomp_ktms(cond1_data, cond2_data, 'alpha', 0.05, 'iterations', 10000, 'ktms_u', 2)
 %
 %
-% outputs:
-% corrected_h (vector of hypothesis tests in which statistical significance
-% is defined by values above a threshold of the (alpha_level * 100)th percentile
-% of the maximum statistic distribution.
-% 1 = statistically significant, 0 = not statistically significant)
-%__________________________________________________________________________
+% Copyright (c) 2016 Daniel Feuerriegel and contributors
+% 
+% This file is part of DDTBOX.
 %
-% Variable naming convention: STRUCTURE_NAME.example_variable
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 %% Handling variadic inputs
 % Define defaults at the beginning

--- a/multcomp_ktms.m
+++ b/multcomp_ktms.m
@@ -15,14 +15,26 @@ function [corrected_h] = multcomp_ktms(cond1_data, cond2_data, varargin)
 % Inputs:
 %
 %   cond1_data      data from condition 1, a subjects x time windows matrix
+%
 %   cond2_data      data from condition 2, a subjects x time windows matrix
+%
+%  'Key1'          Keyword string for argument 1
+%
+%   Value1         Value of argument 1
+%
+%   ...            ...
+%
+% Optional Keyword Inputs:
+%
 %   alpha           uncorrected alpha level for statistical significance, 
 %                   default 0.05
+%
 %   iterations      number of permutation samples to draw, default 5000. 
 %                   At least 1000 is recommended for the p = 0.05 alpha level, 
 %                   and at least 5000 is recommended for the p = 0.01 alpha level.
 %                   This is due to extreme events at the tails being very rare, 
 %                   needing many random permutations to find enough of them.
+%
 %   ktms_u          the u parameter of the procedure, or the number of hypotheses
 %                   to automatically reject. Allowing for more false discoveries
 %                   improves the sensitivity of the method to find real effects. 

--- a/prepare_my_vectors_erp.m
+++ b/prepare_my_vectors_erp.m
@@ -1,23 +1,39 @@
 function [RESULTS] =  prepare_my_vectors_erp(training_set, test_set, SLIST, STUDY)
-%__________________________________________________________________________
-% DDTBOX script written by Stefan Bode 01/03/2013
 %
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
-%
-% The author further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
-%__________________________________________________________________________
 %
 % This function gets input from DECODING_ERP.m and organises the data stored in 
 % training_set and test_set for classification. The data is cut out and handed 
 % over to do_my_classification.m as data vectors and labels. 
 % The output is handed back to DECODING_ERP.
 %
-%__________________________________________________________________________
+% Inputs:
+%   
+%   training_set    data used for training the classifier
+%   test_set        data used to test classifier performance
+%   SLIST           structure containing participant dataset information
+%   STUDY           structure containing multivariate classification/regression settings
 %
-% Variable naming convention: STRUCTURE_NAME.example_variable
+% Outputs:
+%
+%   RESULTS         Structure containing the decoding results
+%
+%
+% Copyright (c) 2013-2016 Stefan Bode and contributors
+% 
+% This file is part of DDTBOX.
+%
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 %% DEFINE NUMBER OF STEPS (default = all possible steps)

--- a/prepare_my_vectors_erp.m
+++ b/prepare_my_vectors_erp.m
@@ -1,16 +1,19 @@
 function [RESULTS] =  prepare_my_vectors_erp(training_set, test_set, SLIST, STUDY)
 %
 %
-% This function gets input from DECODING_ERP.m and organises the data stored in 
+% This function gets input from decoding_erp.m and organises the data stored in 
 % training_set and test_set for classification. The data is cut out and handed 
 % over to do_my_classification.m as data vectors and labels. 
-% The output is handed back to DECODING_ERP.
+% The output is handed back to decoding_erp.
 %
 % Inputs:
 %   
 %   training_set    data used for training the classifier
+%
 %   test_set        data used to test classifier performance
+%
 %   SLIST           structure containing participant dataset information
+%
 %   STUDY           structure containing multivariate classification/regression settings
 %
 % Outputs:

--- a/yuend_ttest.m
+++ b/yuend_ttest.m
@@ -8,43 +8,35 @@ function [h_yuen, p, CI, t_yuen, diff, se, tcrit, df] = yuend_ttest(cond_1_data,
 % t statistic output is modified so that the same output arguments can be
 % used as the MATLAB ttest function, stored in t_yuen.tstat. 
 % 
-% required:
-% - cond_1_data (vectors of observations in group 1)
-% - cond_2_data (vectors of observations in group 2)
+% Inputs:
 %
-% optional:
-% - percent (percent trimming, must be between 0 and 100. Default = 20)
-% - alpha (alpha level. Default = 0.05)
+%   cond_1_data     vectors of observations in condition 1.
+%   cond_2_data     vectors of observations in condition 2.
+%   percent         percent trimming, must be between 0 and 100. 
+%                   Default = 20 corresponding to 20% trimmed mean.
+%   alpha           alpha level. Default = 0.05
 %
-% outputs:
+% Outputs:
 %
-% - t_yuen.tstat (Yuen T statistic. t_yuen is distributed approximately as Student's t 
-%      with estimated degrees of freedom, df)
-% - diff (difference between trimmed means of cond_1_data and cond_2_data)
-% - se (standard error)
-% - CI (confidence interval around the difference)
-% - p (p value)
-% - tcrit (1 - alpha / 2 quantile of the Student's t distribution with
-%   adjusted degrees of freedom)
-% - df (degrees of freedom)
+%   t_yuen.tstat    Yuen T statistic. t_yuen is distributed approximately as Student's t 
+%                   with estimated degrees of freedom, df.
+%   diff            difference between trimmed means of cond_1_data and cond_2_data
+%   se              standard error.
+%   CI              confidence interval around the difference.
+%   p               p-value.
+%   tcrit           1 - alpha / 2 quantile of the Student's t distribution with
+%                   adjusted degrees of freedom.
+%   df              adjusted degrees of freedom.
+%
+% Example:    [h_yuen, p, CI, t_yuen, diff, se, tcrit, df] = yuend_ttest(cond_1_data, cond_2_data, 20, 0.05)  
+%
 %
 % See Wilcox (2012), Introduction to Robust Estimation and Hypothesis
 % Testing (3rd Edition), page 195-198 for a description of the Yuen
-% procedure for dependent groups.
-%
-% _________________________________________________________________________
-% 
-% Written by Daniel Feuerriegel to complement DDTBOX scripts written by Stefan Bode 01/03/2013.
-%
-% The toolbox was written with contributions from:
-% Daniel Bennett, Daniel Feuerriegel, Phillip Alday
-%
-% The author (Stefan Bode) further acknowledges helpful conceptual input/work from: 
-% Jutta Stahl, Simon Lilburn, Philip L. Smith, Elaine Corbett, Carsten Murawski, 
-% Carsten Bogler, John-Dylan Haynes
+% procedure for dependent groups. 
 %
 %
-% Modified from the limo_yuend_ttest function in the LIMO Toolbox:
+% Modified by Daniel Feuerriegel from the limo_yuend_ttest function in the LIMO Toolbox:
 % Pernet, C.R., Chauveau, N., Gaspar, C. & Rousselet, G.A. 
 % LIMO EEG: a toolbox for hierarchical LInear Modeling of EletroEncephaloGraphic data.
 % Computational Intelligence and Neuroscience, Volume 2011 (2011), Article ID 831409, 
@@ -55,14 +47,29 @@ function [h_yuen, p, CI, t_yuen, diff, se, tcrit, df] = yuend_ttest(cond_1_data,
 % 3D, standalone version: GAR, University of Glasgow, June 2010
 % GAR fixed bug for covariance / se
 %
-
+% Modified version copyright (c) 2016 Daniel Feuerriegel and contributors
+%
+% This file is part of DDTBox
+%
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 % Defaults
 if nargin < 4 
-    alpha = .05; 
+    alpha = .05; % Set default alpha level of 0.05
 end
 if nargin < 3
-    percent = 20;
+    percent = 20; % Set default trimming level at 20 percent
 end
 
 if isempty(cond_1_data) || isempty(cond_2_data) 

--- a/yuend_ttest.m
+++ b/yuend_ttest.m
@@ -1,9 +1,7 @@
 function [h_yuen, p, CI, t_yuen, diff, se, tcrit, df] = yuend_ttest(cond_1_data, cond_2_data, percent, alpha)
-
-% function [t_yuen, diff, se, CI, p, tcrit, df] = limo_yuend_ttest(cond_1_data, cond_2_data, percent, alpha)
 %
 % Computes t_yuen (Yuen's T statistic) to compare the trimmed means of two
-% DEPENDENT groups (each group needs the same number of data points).
+% dependent groups (each group needs the same number of data points).
 % 
 % t statistic output is modified so that the same output arguments can be
 % used as the MATLAB ttest function, stored in t_yuen.tstat. 
@@ -11,22 +9,31 @@ function [h_yuen, p, CI, t_yuen, diff, se, tcrit, df] = yuend_ttest(cond_1_data,
 % Inputs:
 %
 %   cond_1_data     vectors of observations in condition 1.
+%
 %   cond_2_data     vectors of observations in condition 2.
+%
 %   percent         percent trimming, must be between 0 and 100. 
 %                   Default = 20 corresponding to 20% trimmed mean.
+%
 %   alpha           alpha level. Default = 0.05
 %
 % Outputs:
 %
 %   t_yuen.tstat    Yuen T statistic. t_yuen is distributed approximately as Student's t 
 %                   with estimated degrees of freedom, df.
+%
 %   diff            difference between trimmed means of cond_1_data and cond_2_data
-%   se              standard error.
-%   CI              confidence interval around the difference.
-%   p               p-value.
+%
+%   se              standard error
+%
+%   CI              confidence interval around the difference
+%
+%   p               p-value
+%
 %   tcrit           1 - alpha / 2 quantile of the Student's t distribution with
-%                   adjusted degrees of freedom.
-%   df              adjusted degrees of freedom.
+%                   adjusted degrees of freedom
+%
+%   df              adjusted degrees of freedom
 %
 % Example:    [h_yuen, p, CI, t_yuen, diff, se, tcrit, df] = yuend_ttest(cond_1_data, cond_2_data, 20, 0.05)  
 %


### PR DESCRIPTION
As per original pull request:

Modified function and script headers to the style specified in EEGLab example scripts. For examples and guidelines see the EEGLab Wiki

The list of contributing authors has been changed to naming the original author of the script and "contributors" rather than to list all names.

Conceptual input acknowledgements have been removed from scripts.

Copyright and GNU GPL license information has been added to the headers.

Information about input and output variables/matrices/structures have been added.

Examples of how to call each function have been added to functions with which the end user will interact.
