### PR TITLE
Fixed bugs in prepare_my_vectors_erp.

### DIFF
--- a/prepare_my_vectors_erp.m
+++ b/prepare_my_vectors_erp.m
@@ -133,9 +133,16 @@ for main_analysis = 1:nr_rounds % 1=real decoding, 2=permutation test
                                 for trl = 1:size(temp,2)
                                     labels_train = [labels_train  training_labels{1,con,cv,ncv}(trl)];
                                 end
-                                clear temp;
-                                                               
+                            
+                            else % if not SVR
+                                
+                                for ntrls = 1:(size(temp,2))
+                                    labels_train = [labels_train con];
+                                end
+                                
                             end % if SVR
+                            
+                            clear temp;
                             %________________________________________________________________________________
                             
                             % permutation test data %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -156,7 +163,7 @@ for main_analysis = 1:nr_rounds % 1=real decoding, 2=permutation test
                         
                             % Test data vectors
                             temp(:,:) = mean_data_test(1,:,:);
-                            vectors_test = [vectors_test temp];      
+                            vectors_test = [vectors_test temp];     
                             
                             %________________________________________________________________________________
                             if STUDY.analysis_mode == 3 % if SVR
@@ -164,9 +171,16 @@ for main_analysis = 1:nr_rounds % 1=real decoding, 2=permutation test
                                 for trl = 1:size(temp,2)
                                     labels_test = [labels_test  test_labels{1,con,cv,ncv}(trl)];
                                 end
-                                clear temp;                                  
+                                
+                            else % if not SVR
+                                
+                                for ntrls = 1:(size(temp,2))
+                                    labels_test = [labels_test con];
+                                end  
                                                           
                             end % if SVR
+                            
+                            clear temp;
                             %________________________________________________________________________________
                         
                         % temporal decoding: vectors consist of single data-points within time
@@ -182,9 +196,14 @@ for main_analysis = 1:nr_rounds % 1=real decoding, 2=permutation test
                                 if STUDY.analysis_mode == 3 % if SVR
                                         
                                     labels_train = [labels_train training_labels{1,con,cv,ncv}(exmpl)];
-                                    clear temp;
-                                                                           
+                                      
+                                else % if not SVR
+                                    
+                                    labels_train=[labels_train con];
+                                    
                                 end % if SVR
+                                
+                                clear temp;
                                 %________________________________________________________________________________
                                 
                             end % exmpl
@@ -216,9 +235,14 @@ for main_analysis = 1:nr_rounds % 1=real decoding, 2=permutation test
                                     for ntrls = 1:size(temp,2)
                                         labels_test = [labels_test  test_labels{1,con,cv,ncv}(exmpl)];
                                     end
-                                    clear temp;
-                                                               
+                                      
+                                else % if not SVR
+                                    
+                                    labels_test=[labels_test con];
+                                    
                                 end % if SVR
+                                
+                                clear temp;
                                 %________________________________________________________________________________
                                 
                             end % exmpl 
@@ -244,7 +268,11 @@ for main_analysis = 1:nr_rounds % 1=real decoding, 2=permutation test
                                 if STUDY.analysis_mode == 3 % if SVR
                                         
                                     labels_train = [labels_train training_labels{1,con,cv,ncv}(exmpl)];
-                                        
+                                  
+                                else % if not SVR
+                                    
+                                    labels_train = [labels_train con];
+                                    
                                 end % if SVR
                                 %________________________________________________________________________________
                                 
@@ -281,7 +309,12 @@ for main_analysis = 1:nr_rounds % 1=real decoding, 2=permutation test
                                 if STUDY.analysis_mode == 3 % if SVR
                                         
                                     labels_test = [labels_test test_labels{1,con,cv,ncv}(exmpl)];
-                                                                                                     
+                                      
+                                else % if not SVR
+                                    
+                                    labels_test = [labels_test con];
+                                    
+                                    
                                 end % if SVR
                                 %________________________________________________________________________________
                                 


### PR DESCRIPTION
Fixes two bugs in prepare_my_vectors_erp

First bug was that the temp matrices were being cleared too early (as they are supposed to be used for determining the number of condition labels for training and test data).
The temp matrices are now cleared after they have been used to create the condition labels.

Second bug was that code for creating training and test condition labels (for non SVR data) was removed in an earlier bugfix, and so the SVM classifiers did not have any labels to use when SVR was not chosen.
Code for creating condition labels has now been put back into prepare_my_vectors_erp.