### PR TITLE
Adding Feature Weights Conversion

### DIFF
--- a/ANALYSE_DECODING_ERP.m
+++ b/ANALYSE_DECODING_ERP.m
@@ -77,6 +77,7 @@ if input_mode == 0 % Hard-coded input
     ANALYSIS.disp.sign = 1; % display statistically significant steps in results figure? 0=no / 1=yes
     
     ANALYSIS.fw.do = 1; % analyse feature weights? 0=no / 1=yes
+    ANALYSIS.fw.corrected = 1; % Use feature weights corrected using Haufe et al. (2014) method? 0=no / 1=yes
     ANALYSIS.fw.multcompstats = 1; % Feature weights correction for multiple comparisons:
     % 1 = Bonferroni correction
     % 2 = Holm-Bonferroni correction
@@ -157,6 +158,7 @@ elseif input_mode == 1 % Prompted manual input
     ANALYSIS.fw.do = input('Do you wish to analyse the feature weights (only for spatial or spatio-temporal decoding)? "0" for no; "1" for yes: ');
     
     if ANALYSIS.fw.do == 1
+        ANALYSIS.fw.corrected = input('Use feature weights corrected using Haufe et al. (2014) method? "0" for no; "1" for yes: ');
         ANALYSIS.fw.multcompstats = input(['\nSpecify which multiple comparisons correction method to use: \n' ...
         '"1" for Bonferroni \n"2" for Holm-Bonferroni \n"3" for Strong FWER Control Permutation Testing \n' ...
         '"4" for Cluster-Based Permutation Testing (Currently not available) \n"5" for KTMS Generalised FWER Control \n' ...
@@ -346,6 +348,7 @@ for s = 1:ANALYSIS.nsbj
     % Extract feature weights
     if ~isempty(RESULTS.feature_weights)
         ANALYSIS.RES.feature_weights{s} = RESULTS.feature_weights{1};
+        ANALYSIS.RES.feature_weights_corrected{s} = RESULTS.feature_weights_corrected{1};
     end
     
     clear RESULTS;

--- a/analyse_feature_weights_erp.m
+++ b/analyse_feature_weights_erp.m
@@ -39,7 +39,7 @@ for sbj = 1:ANALYSIS.nsbj
            
     %% collect data from all participants
     % results are stored in:
-    % RESULTS.feature_weights{analysis}{time_step,cross_val_step,repetition_step}=(data_point,feature_weight,absolute_feature_weight)
+    % RESULTS.feature_weights{analysis}{time_step,cross_val_step,repetition_step}=(feature_number,feature_weight,absolute_feature_weight)
     %
     % Feature weights are then averaged. Attention - averaged absolute
     % feature weights are not just | average feature weights | (!!!)
@@ -57,8 +57,17 @@ for sbj = 1:ANALYSIS.nsbj
                 
                 for rep = 1:size(ANALYSIS.RES.feature_weights{sbj},3)
                     
-                    temp_step_fw = ANALYSIS.RES.feature_weights{1,sbj}{steps,cross_val,rep}(:,2);
-                    temp_step_abs = ANALYSIS.RES.feature_weights{1,sbj}{steps,cross_val,rep}(:,3);
+                    if ANALYSIS.fw.corrected == 0 % if analysing uncorrected feature weights
+                        
+                        temp_step_fw = ANALYSIS.RES.feature_weights{1,sbj}{steps,cross_val,rep}(:,2);
+                        temp_step_abs = ANALYSIS.RES.feature_weights{1,sbj}{steps,cross_val,rep}(:,3); 
+                        
+                    elseif ANALYSIS.fw.corrected == 1 % if analysing corrected feature weights
+                        
+                        temp_step_fw = ANALYSIS.RES.feature_weights_corrected{1,sbj}{steps,cross_val,rep}(:,2);
+                        temp_step_abs = ANALYSIS.RES.feature_weights_corrected{1,sbj}{steps,cross_val,rep}(:,3); 
+                        
+                    end % of if ANALYSIS.fw.corrected
                     
                     FW_ANALYSIS.ALL_FW{sbj,steps,cross_val,rep} = temp_step_fw; % feature weights
                     FW_ANALYSIS.ALL_FW{sbj,steps,cross_val,rep}(:,2) = temp_step_abs; % absolute feature weights

--- a/do_my_classification.m
+++ b/do_my_classification.m
@@ -1,4 +1,4 @@
-function [acc,feat_weights] = do_my_classification(vectors_train,labels_train,vectors_test,labels_test,STUDY)
+function [acc,feat_weights, feat_weights_corrected] = do_my_classification(vectors_train,labels_train,vectors_test,labels_test,STUDY)
 %__________________________________________________________________________
 % DDTBOX script written by Stefan Bode 01/03/2013
 %
@@ -55,11 +55,20 @@ if STUDY.analysis_mode == 1 % SVM classification with libsvm
     b = -model.rho;
 
     feat_weights = zeros(size(w,1),3);
+    feat_weights_corrected = zeros(size(w,1),3);
     
     if STUDY.feat_weights_mode == 1 
+        % uncorrected feature weights
         feat_weights(:,1) = 1:(size(w,1));
         feat_weights(:,2) = w;
         feat_weights(:,3) = abs(w);
+        
+        % corrected feature weights according to Haufe et al. (2014) method
+        feat_weights_corrected(:,1) = 1:(size(w,1));
+        vectors_train_temp = (vectors_train - repmat(mean(vectors_train), size(vectors_train, 1), 1)) ./ sqrt(size(vectors_train, 1) - 1);
+        feat_weights_corrected(:,2) = vectors_train_temp' * (vectors_train_temp * feat_weights(:,2));
+        clear vectors_train_temp;
+        feat_weights_corrected(:,3) = abs(feat_weights_corrected(:,2));
     end
 
     % extracting accuracy for 2-classes 
@@ -93,11 +102,20 @@ elseif STUDY.analysis_mode == 2 % SVM classification with liblinear
     w = model.w';
 
     feat_weights = zeros(size(w,1),3);
+    feat_weights_corrected = zeros(size(w,1),3);
     
     if STUDY.feat_weights_mode == 1 
+        % uncorrected feature weights
         feat_weights(:,1) = 1:(size(w,1));
         feat_weights(:,2) = w;
         feat_weights(:,3) = abs(w);
+        
+        % corrected feature weights according to Haufe et al. (2014) method
+        feat_weights_corrected(:,1) = 1:(size(w,1));
+        vectors_train_temp = (vectors_train - repmat(mean(vectors_train), size(vectors_train, 1), 1)) ./ sqrt(size(vectors_train, 1) - 1);
+        feat_weights_corrected(:,2) = vectors_train_temp' * (vectors_train_temp * feat_weights(:,2));
+        clear vectors_train_temp;
+        feat_weights_corrected(:,3) = abs(feat_weights_corrected(:,2));
     end
 
     % extracting accuracy for 2-classes 
@@ -141,11 +159,20 @@ elseif STUDY.analysis_mode == 3 % SVR
     % calculating feature weights
     w = model.SVs' * model.sv_coef;
     feat_weights = zeros(size(w,1),3);  
+    feat_weights_corrected = zeros(size(w,1),3);
     
     if STUDY.feat_weights_mode == 1
+        % uncorrected feature weights
         feat_weights(:,1) = 1:(size(w,1));
         feat_weights(:,2) = w;
         feat_weights(:,3) = abs(w);
+        
+        % corrected feature weights according to Haufe et al. (2014) method
+        feat_weights_corrected(:,1) = 1:(size(w,1));
+        vectors_train_temp = (vectors_train - repmat(mean(vectors_train), size(vectors_train, 1), 1)) ./ sqrt(size(vectors_train, 1) - 1);
+        feat_weights_corrected(:,2) = vectors_train_temp' * (vectors_train_temp * feat_weights(:,2));
+        clear vectors_train_temp;
+        feat_weights_corrected(:,3) = abs(feat_weights_corrected(:,2));
     end
     
 end % if analysis_mode

--- a/prepare_my_vectors_erp.m
+++ b/prepare_my_vectors_erp.m
@@ -385,17 +385,19 @@ for main_analysis = 1:nr_rounds % 1=real decoding, 2=permutation test
                     elseif main_analysis == 2
                         fprintf('Permutation test step %d of %d steps, cross-validation step %d in cycle %d: \n',s,nsteps,cv,rep);
                     end
-                    [acc,feat_weights] = do_my_classification(vectors_train,labels_train,vectors_test,labels_test,STUDY);
+                    [acc,feat_weights, feat_weights_corrected] = do_my_classification(vectors_train,labels_train,vectors_test,labels_test,STUDY);
                 
                     if main_analysis == 1
                         RESULTS.prediction_accuracy{ch}(s,cv,rep) = acc;
                         RESULTS.feature_weights{ch}{s,cv,rep} = feat_weights;
+                        RESULTS.feature_weights_corrected{ch}{s,cv,rep} = feat_weights_corrected;
                     elseif main_analysis == 2
                         RESULTS.perm_prediction_accuracy{ch}(s,cv,repetition_data_steps(rep)) = acc;           
                     end
                         
                     clear acc;
                     clear feat_weights;
+                    clear feat_weights_corrected;
                     
                 end % steps
                     


### PR DESCRIPTION
Added capability to calculate corrected feature weights according to Haufe et al. (2014) method. This transforms a linear backward model into a linear forward model, and makes the feature weights interpretable.

Haufe et al. (2014). On the interpretation of weight vectors of linear models in multivariate neuroimaging. Neuroimage, 85(15), 96-110. doi 10.1016/j.neuroimage.2013.10.067

This correction is performed automatically if feature weight extraction is selected.

Added options to plot corrected feature weights analysis results at the group level.

Note that this is a new version of the feature-weights-conversion branch but incorporating the updates from the dev branch (to make merging simpler).