### PR TITLE
Fixed a variable name typo in the min_statistic_classifier_accuracies

### DIFF
--- a/min_statistic_classifier_accuracies.m
+++ b/min_statistic_classifier_accuracies.m
@@ -122,7 +122,7 @@ end % of for na (loop through analyses)
      
      ANALYSIS.RES.h = ANALYSIS.RES.h_minstat_corrected;
      
- elseif ANALYSIS.minstate_multcomp == 0
+ elseif ANALYSIS.minstat_multcomp == 0
 
      ANALYSIS.RES.h = ANALYSIS.RES.h_minstat_uncorrected;
 


### PR DESCRIPTION
Fixed variable name in minimum statistic method script. DDTBOX previously gave an error because of this variable name error.