### PR TITLE
Cluster Permtest Multcomp Bugfix

### DIFF
--- a/t_tests_classifier_accuracies.m
+++ b/t_tests_classifier_accuracies.m
@@ -225,7 +225,7 @@ case 4 % Cluster-Based Permutation Test
         ANALYSIS.RES.cluster_sig{na} = MCC_Results.cluster_sig;
         ANALYSIS.RES.cluster_p{na} = MCC_Results.cluster_p;
         fprintf('The adjusted critical cluster mass for analysis %i is %3.3f \n', na, ANALYSIS.RES.critical_cluster_mass(na));
-        fprintf('%i statistically significant clusters were found for analysis %i \n', Results.RES.n_sig_clusters, na);
+        fprintf('%i statistically significant clusters were found for analysis %i \n', ANALYSIS.RES.n_sig_clusters, na);
 
     end % of for na loop
     clear real_decoding_scores


### PR DESCRIPTION
Fixed bug where DDTBOX looked for an entry in the old/unused 'Results' structure when printing the results of the cluster permtest multiple comparisons correction.

This has been changed to access the same variable from the ANALYSIS.RES structure.