### PR TITLE
Removed unused settings from decoding configuration script

### DIFF
--- a/EXAMPLE_run_decoding_analyses.m
+++ b/EXAMPLE_run_decoding_analyses.m
@@ -66,8 +66,6 @@ data_struct_name = 'eeg_sorted_cond'; % Data arrays for use with DDTBOX must use
 %% EEG dataset information
 
 nchannels = 64; % number of channels
-channel_names_file = 'channel_inf.mat'; % Name of .mat file containing channel labels and channel locations
-channellocs = [bdir, 'locations/']; % Path of directory containing channel information file
 sampling_rate = 1000; % Data sampling rate in Hz
 pointzero = 100; % Corresponds to the time of the event/trigger code relative to the prestimulus baseline (in ms)
 


### PR DESCRIPTION
Removed entries of channel_names_file and channellocs from decoding configuration script, as they are not used by this set of functions