### PR TITLE
Bugfix for plotting temporal decoding results through decoding_erp

### DIFF
--- a/decoding_erp.m
+++ b/decoding_erp.m
@@ -662,7 +662,7 @@ if cfg.display_on == 1
     % Load default plotting parameters for single subject plots
     PLOT = dd_set_plotting_defaults_indiv;
     PLOT.channel_names_file = cfg.channel_names_file;
-    PLOT.chanellocs = cfg.channellocs;
+    PLOT.channellocs = cfg.channellocs;
     
     % Call individual results display function
     display_indiv_results_erp(cfg, RESULTS, PLOT);


### PR DESCRIPTION
Fixed typo in channel locations variable assignment (previously caused DDTBOX to crash when plotting results of individual subject temporal decoding results through decoding_erp).