### PR TITLE
Fixed bug in single subject results plotting script

### DIFF
--- a/EXAMPLE_plot_individual_results.m
+++ b/EXAMPLE_plot_individual_results.m
@@ -51,7 +51,7 @@ window_width_ms =10; % width of sliding window in ms
 step_width_ms = 400; % step size with which sliding window is moved through the trial
 
 % Create labels based on SVM method used
-switch avmode
+switch analysis_mode
     case 1 % SVC with LIBSVM
         analysis_mode_label = 'SVM_LIBSVM';
     case 2 % SVC with LIBLINEAR


### PR DESCRIPTION
Fixed bug where the individual results plotting script was using avmode (averaging mode) to determine which classifier was used (i.e. what analysis_mode was used, LIBSVM or LIBLINEAR).

The script now correctly sets the LIBSVM/LIBLINEAR label based on analysis_mode.