### PR TITLE
Minor bugfixes following release v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-[![DOI](https://zenodo.org/badge/20756/DDTBOX/DDTBOX.svg)](https://zenodo.org/badge/latestdoi/20756/DDTBOX/DDTBOX)
 # DDTBOX
 Decision Decoding Toolbox
 
 
-Copyright (c) 2013--2016 Stefan Bode and contributors.
+Copyright (c) 2013--2017 Stefan Bode and contributors.
 
 Unless otherwise specified, code is distributed under the GNU Public License (GPL) version 2, and documentation under a Creative Commons Attribution-Share-Alike 4.0 International license.
 
@@ -11,14 +10,14 @@ Unless otherwise specified, code is distributed under the GNU Public License (GP
 
 We hope that you find the software and documentation useful.
 If you publish an analysis using the toolbox, we ask that you cite us. 
-For now, please cite us via GitHub, but we are currently preparing on a publication to submit to peer review. 
-A sample citation would be:
+We are currently preparing on a publication to submit to peer review. 
+For now, please cite our BioRxiv preprint:
 
-Bode, S., Bennett, D., Feuerriegel, D., & Alday, P. (2016). The Decision Decoding Toolbox -- a multivariate pattern analysis toolbox for event-related potentials. DOI: 10.5281/zenodo.48143
+Bode, S., Feuerriegel, D., Bennett, D., & Alday, P.M. (2017). The Decision Decoding ToolBOX (DDTBOX) -- A multivariate pattern analysis toolbox for event-related potentials. DOI: 10.1101/153189 
 
 # External Dependencies
 
-The code in the toolbox depends on the functionality supplied by [LIBSVM](https://www.csie.ntu.edu.tw/~cjlin/libsvm/).
-In the future, we hope to offer support for LIBSVM's specialised and often faster cousin, [LIBLINEAR](https://www.csie.ntu.edu.tw/~cjlin/liblinear/), as well as potentially other backends for other classifiers. 
-You need to configure MATLAB to use these external dependencies.
+The code in the toolbox depends on the functionality supplied by [LIBSVM](https://www.csie.ntu.edu.tw/~cjlin/libsvm/) and it's specialised and often faster cousin, [LIBLINEAR](https://www.csie.ntu.edu.tw/~cjlin/liblinear/).
+These libraries are included in releases from v1.0 onwards.
+In some cases you may need to configure MATLAB to use these external dependencies.
 Please see their respective documentation for more information. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # DDTBOX
 Decision Decoding Toolbox
 
-
 Copyright (c) 2013--2017 Stefan Bode and contributors.
 
 Unless otherwise specified, code is distributed under the GNU Public License (GPL) version 2, and documentation under a Creative Commons Attribution-Share-Alike 4.0 International license.
@@ -10,14 +9,17 @@ Unless otherwise specified, code is distributed under the GNU Public License (GP
 
 We hope that you find the software and documentation useful.
 If you publish an analysis using the toolbox, we ask that you cite us. 
-We are currently preparing on a publication to submit to peer review. 
-For now, please cite our BioRxiv preprint:
+For now, please cite us via GitHub, but we are currently preparing on a publication to submit to peer review. 
+A sample citation would be:
 
-Bode, S., Feuerriegel, D., Bennett, D., & Alday, P.M. (2017). The Decision Decoding ToolBOX (DDTBOX) -- A multivariate pattern analysis toolbox for event-related potentials. DOI: 10.1101/153189 
+Bode, S., Feuerriegel, D., Bennett, D., & Alday, P. (2017). The Decision Decoding ToolBOX (DDTBOX) -- A multivariate pattern analysis toolbox for event-related potentials. DOI: 10.5281/zenodo.48143
+
+[![DOI](https://zenodo.org/badge/20756/DDTBOX/DDTBOX.svg)](https://zenodo.org/badge/latestdoi/20756/DDTBOX/DDTBOX)
+
+If using a version from the master or development branch, please include the [commit hash](http://codetunnel.io/merge-vs-rebase-part-1-what-is-a-commit-hash/) in your citation so that others can identify the exact version of the code used for analyses.
 
 # External Dependencies
 
-The code in the toolbox depends on the functionality supplied by [LIBSVM](https://www.csie.ntu.edu.tw/~cjlin/libsvm/) and it's specialised and often faster cousin, [LIBLINEAR](https://www.csie.ntu.edu.tw/~cjlin/liblinear/).
-These libraries are included in releases from v1.0 onwards.
-In some cases you may need to configure MATLAB to use these external dependencies.
+The code in the toolbox depends on the functionality supplied by [LIBSVM](https://www.csie.ntu.edu.tw/~cjlin/libsvm/) and its specialised and often faster cousin, [LIBLINEAR](https://www.csie.ntu.edu.tw/~cjlin/liblinear/).
+These libraries are included with DDTBOX from v1.0 onwards. In some cases you may need to configure MATLAB to use these external dependencies.
 Please see their respective documentation for more information. 

--- a/analyse_decoding_erp.m
+++ b/analyse_decoding_erp.m
@@ -155,6 +155,10 @@ for s = 1:ANALYSIS.nsbj
         ptz = find(ANALYSIS.data(2,:) == ANALYSIS.pointzero); % find data with PointZero
         ANALYSIS.data(3,ptz) = 1; clear ptz; % for line location in plot
 
+        % copy parameters from the config file
+        ANALYSIS.step_width = cfg.step_width;
+        ANALYSIS.window_width = cfg.window_width;
+        
         % extract Tick/Labels for x-axis
         for datastep = 1:ANALYSIS.laststep
             

--- a/analyse_feature_weights_erp.m
+++ b/analyse_feature_weights_erp.m
@@ -543,6 +543,7 @@ for p_corr = 1:2 % run for corrected/uncorrected
                         'tail', ANALYSIS.fw.ttest_tail);
                     
                     FW_ANALYSIS.h_matrix_z_averagestep_corr = FW_MCC_Results.corrected_h;
+                    FW_ANALYSIS.p_matrix_z_averagestep_corr = FW_MCC_Results.corrected_p;
                     FW_ANALYSIS.p_matrix_z_averagestep_corr_label = FW_MCC_Results.corrected_p;
                     clear real_decoding_fw;
                     clear fw_chance_level;

--- a/t_tests_classifier_accuracies.m
+++ b/t_tests_classifier_accuracies.m
@@ -549,7 +549,7 @@ case 6 % Benjamini-Hochberg FDR Control
             
             [MCC_Results] = multcomp_fdr_bh(ANALYSIS.RES.p_ttest(na,:), 'alpha', ANALYSIS.pstats);
             ANALYSIS.RES.h_ttest(na, :) = MCC_Results.corrected_h;
-            ANALYSIS.RES.bky_crit_alpha(na) = MCC_Results.critical_alpha;
+            ANALYSIS.RES.bh_crit_alpha(na) = MCC_Results.critical_alpha;
             fprintf('The adjusted critical alpha for analysis %i is %1.6f \n\n', na, MCC_Results.critical_alpha(na));
             
         end % of for na
@@ -560,7 +560,7 @@ case 6 % Benjamini-Hochberg FDR Control
             
             [MCC_Results] = multcomp_fdr_bh(ANALYSIS.RES.p_ttest(:, step), 'alpha', ANALYSIS.pstats);
             ANALYSIS.RES.h_ttest(:, step) = MCC_Results.corrected_h;
-            ANALYSIS.RES.bky_crit_alpha(step) = MCC_Results.critical_alpha;
+            ANALYSIS.RES.bh_crit_alpha(step) = MCC_Results.critical_alpha;
             fprintf('The adjusted critical alpha for step %i is %1.6f \n\n', step, MCC_Results.critical_alpha(step));
             
         end % of for step


### PR DESCRIPTION
Updated README to match v1.0.

Fixed some minor bugs in the initial release version, including:

- DDTBOX previously crashed when analysing feature weights from spatiotemporal analyses, as a necessary variable `window_width` was erroneously removed during the v1.0 pre-release code review. The variable is now defined in `analyse_decoding_erp` in the same position as before erroneous removal.

- p-values output from the maximum statistic permutation test for FWs was not copied into the correct location FW_ANALYSIS.p_matrix_z_averagestep_corr`. The corrected p-values are now copied into this vector.

- The adjusted critical alpha for benjamini-hochberg procedure for t test classifier accuracies was erroneously copied as that belonging to the benjamini-krieger-yekutieli multcomp output. This label has been fixed.