### PR TITLE
Bugfix for dd_convert_eeg_data function

### DIFF
--- a/dd_convert_eeg_data.m
+++ b/dd_convert_eeg_data.m
@@ -239,7 +239,12 @@ else % If data type not correctly specified
     
 end % of if strcmp data_type
 
-if ~strcmp(timepoints, 'All') % If user has selected custom time range
+if strcmp(timepoints, 'All') % If all time points within the epoch were included
+    
+    epoch_start_index = 1;
+    epoch_end_index = size(epoched_data, 2);
+    
+else % If user has selected custom time range
     
     % Trim to specified epoch start/end timepoints
     % Find epoch start and end samples (closest timepoints to selected epoch


### PR DESCRIPTION
Resolves Issue #80 

The function `dd_convert_eeg_data` was crashing when the default setting `timepoints` = `All` was used, as the variables `epoch_start_index` and `epoch_end_index` were not created when selecting this setting. As both variables are referred to when populating the `dataset_info` structure, the function would crash. Thanks to matthewhang for reporting this bug.

I added code to create variables `epoch_start_index` and `epoch_end_index` when 'timepoints' = 'All'. This function has been tested by converting EEG data epoched in ERPLab into the DDTBOX-compatible format. The function runs without any issues.