### PR TITLE
Trial randomisation bugfix

### DIFF
--- a/decoding_erp.m
+++ b/decoding_erp.m
@@ -333,10 +333,16 @@ for r = 1:size(reduced_data, 2)
         
         for cond = 1:size(reduced_data, 3)
 
-            % extract min number trials for this DCG and run
+            % extract min number epochs for this DCG and run. If the
+            % minimum number of epochs is less than the full data set, a
+            % random subset of epochs is selected
             temp_data = reduced_data{d, r, cond};
-            balanced_data{d,r, cond} = temp_data(:, :, 1:(cfg.mintrs_min(r)));
+            random_trials = sort(randperm(size(temp_data, 3), cfg.mintrs_min(r)));
+            balanced_data{d, r, cond} = temp_data(:, :, random_trials);
+
             clear temp_data;
+            clear random trials;
+            
 
         end % of for cond          
     end % of for d

--- a/display_indiv_results_erp.m
+++ b/display_indiv_results_erp.m
@@ -125,13 +125,13 @@ if cfg.stmode == 1 || cfg.stmode == 3 % Spatial and spatiotemporal decoding
     % Title of plot
     if cfg.cross == 0 % If did not perform cross-decoding
         
-        title(['SBJ', num2str(cfg.sbj_todo), ' ', cfg.dcg_labels{1}, ' - analysis ', num2str(1), ' of ', num2str(size(RESULTS.subj_acc, 1))], ...
+        title(['SBJ', num2str(cfg.sbj_todo), ' ', cfg.dcg_labels{cfg.dcg_todo}, ' - analysis ', num2str(1), ' of ', num2str(size(RESULTS.subj_acc, 1))], ...
             'FontSize', 14, ...
             'FontWeight', 'b');
         
     elseif cfg.cross == 1 % If performed cross-decoding
         
-        title(['SBJ', num2str(cfg.sbj_todo), ' ', cfg.dcg_labels{1}, ' train ', cfg.dcg_labels{2}, ' test ', '- analysis ', num2str(1), ' of ', num2str(size(RESULTS.subj_acc, 1))], ...
+        title(['SBJ', num2str(cfg.sbj_todo), ' ', cfg.dcg_labels{cfg.dcg_todo(1)}, ' train ', cfg.dcg_labels{cfg.dcg_todo(2)}, ' test ', '- analysis ', num2str(1), ' of ', num2str(size(RESULTS.subj_acc, 1))], ...
             'FontSize', 14, ...
             'FontWeight', 'b');
         
@@ -173,11 +173,11 @@ elseif cfg.stmode == 2 % Temporal decoding
     % Title of plot
     if cfg.cross == 0 % If did not perform cross-decoding
         
-        title(['SBJ', num2str(cfg.sbj_todo), ' ', cfg.dcg_labels{1}], 'FontSize', 14, 'FontWeight', 'b');
+        title(['SBJ', num2str(cfg.sbj_todo), ' ', cfg.dcg_labels{cfg.dcg_todo}], 'FontSize', 14, 'FontWeight', 'b');
             
     elseif cfg.cross == 1 % If performed cross-decoding
         
-        title(['SBJ', num2str(cfg.sbj_todo), ' ', cfg.dcg_labels{1}, ' train ', cfg.dcg_labels{2}, ' test'], 'FontSize', 14, 'FontWeight', 'b');
+        title(['SBJ', num2str(cfg.sbj_todo), ' ', cfg.dcg_labels{cfg.dcg_todo(1)}, ' train ', cfg.dcg_labels{cfg.dcg_todo(2)}, ' test'], 'FontSize', 14, 'FontWeight', 'b');
         
     end % of if cfg.cross
     
@@ -198,13 +198,13 @@ elseif cfg.stmode == 2 % Temporal decoding
         % Title of plot
         if cfg.cross == 0 % If did not perform cross-decoding
             
-            title(['SBJ', num2str(cfg.sbj_todo), ' ', cfg.dcg_labels{1}, ' Permutation Decoding Results'], ...
+            title(['SBJ', num2str(cfg.sbj_todo), ' ', cfg.dcg_labels{cfg.dcg_todo}, ' Permutation Decoding Results'], ...
                 'FontSize', 14, ...
                 'FontWeight', 'b');
 
         elseif cfg.cross == 1 % If performed cross-decoding
             
-            title(['SBJ', num2str(cfg.sbj_todo), ' ', cfg.dcg_labels{1}, ' train ', cfg.dcg_labels{2}, ' test', ' Permutation Decoding Results'], ...
+            title(['SBJ', num2str(cfg.sbj_todo), ' ', cfg.dcg_labels{cfg.dcg_todo(1)}, ' train ', cfg.dcg_labels{cfg.dcg_todo(2)}, ' test', ' Permutation Decoding Results'], ...
                 'FontSize', 14, ...
                 'FontWeight', 'b');
             


### PR DESCRIPTION
Two small bugfixes for different issues in the code:

- Fixed bug relating to plotting individual subject results. Previously the first dcg name was always used as the plot title, now it changes the title based on the dcg used. This is also fixed for cross decoding. 

- When balancing trial numbers, DDTBOX now selects a random subset of epochs from a larger pool of trials, for situations where one condition has more epochs than the other condition. Before this, the first X epochs were taken for the condition data that had a larger number of epochs. Thanks to Prof. Jutta Stahl for bringing this to our attention!