### PR TITLE
Addition of quiet mode with no MATLAB command line output by LIBSVM/LIBLINEAR

### DIFF
--- a/EXAMPLE_run_decoding_analyses.m
+++ b/EXAMPLE_run_decoding_analyses.m
@@ -182,6 +182,8 @@ feat_weights_mode = 1; % Extract feature weights? 0 = no / 1 = yes
 display_on = 1; % Display single subject decoding performance results? 0 = no / 1 = yes
 perm_disp = 1; % Display the permuted labels decoding results in figure? 0 = no / 1 = yes
 
+% 'quiet mode' option to suppress text output to the command line
+quiet_mode = 0; % 1 = Suppress output / 0 = Allow text output to command line
 
 
 
@@ -220,6 +222,7 @@ cfg.permut_rep = permut_rep;
 cfg.feat_weights_mode = feat_weights_mode;
 cfg.display_on = display_on;
 cfg.perm_disp = perm_disp;
+cfg.quiet_mode = quiet_mode;
 
 
 

--- a/decoding_erp.m
+++ b/decoding_erp.m
@@ -172,16 +172,30 @@ elseif cfg.analysis_mode == 3 % SVR (regression)  with LIBSVM
     
 end % of if cfg.analysis_mode
 
-% Merging all flags into a single string
+% Define 'quiet mode' flag to suppress output if selected by user
+if cfg.quiet_mode == 1 % If using quiet mode
+        
+    cfg.backend_flags.quiet_mode_flag = ' -q ';
+
+else
+
+    cfg.backend_flags.quiet_mode_flag = ' ';
+
+end % of if cfg.quiet_mode
+
+% Merging all flags (except quiet mode flag) into a single string
 cfg.backend_flags.all_flags = ['-s ', int2str(cfg.backend_flags.svm_type), ' -c ', num2str(cfg.backend_flags.cost)];
 
 % LIBSVM specific options
 if cfg.backend_flags.kernel_type ~= -1
+    
 	cfg.backend_flags.all_flags = [cfg.backend_flags.all_flags, ' -t ', int2str(cfg.backend_flags.kernel_type)];
+    
 end % of if cfg.backend_flags.kernel_type
 
-% Add any extra flags defined by the user
-cfg.backend_flags.all_flags = [cfg.backend_flags.all_flags, ' ', cfg.backend_flags.extra_flags];
+% Add any extra flags defined by the user and quiet mode flag
+cfg.backend_flags.all_flags = [cfg.backend_flags.quiet_mode_flag, cfg.backend_flags.all_flags, ' ', cfg.backend_flags.extra_flags];
+
 
 
 %% Section 2: Read In Data

--- a/do_my_classification.m
+++ b/do_my_classification.m
@@ -100,11 +100,11 @@ Labels = labels_test;
 
 if sum(cfg.analysis_mode == [1, 3]) % libsvm
     
-    [predicted_label, accuracy, decision_values] = svmpredict(Labels, Samples, model);
+    [predicted_label, accuracy, decision_values] = svmpredict(Labels, Samples, model, cfg.backend_flags.quiet_mode_flag);
     
 elseif sum(cfg.analysis_mode == [2]) % liblinear
     
-    [predicted_label, accuracy, decision_values] = predict(Labels, sparse(Samples), model); 
+    [predicted_label, accuracy, decision_values] = predict(Labels, sparse(Samples), model, cfg.backend_flags.quiet_mode_flag); 
     
 end % of if sum
 


### PR DESCRIPTION
Added code to allow 'quiet mode' whereby LIBSVM and LIBLINEAR output is suppressed and not printed to the MATLAB command line