### PR TITLE
Normalise data for svm

### DIFF
--- a/EXAMPLE_run_decoding_analyses.m
+++ b/EXAMPLE_run_decoding_analyses.m
@@ -165,6 +165,7 @@ ncond = size(cond_labels, 2);
 %% Multivariate Classification/Regression Parameters
 
 analysis_mode = 1; % ANALYSIS mode (1 = SVM classification with LIBSVM / 2 = SVM classification with LIBLINEAR / 3 = SVR with LIBSVM)
+normalise_data = 1; % Normalise data for each feature prior to decoding? 1 = Yes / 0 = No
 stmode = 1; % SPACETIME mode (1 = spatial / 2 = temporal / 3 = spatio-temporal)
 avmode = 1; % AVERAGE mode (1 = no averaging; use single-trial data / 2 = use run-averaged data). Note: Single trials needed for SVR
 window_width_ms = 50; % Width of sliding analysis window in ms
@@ -220,6 +221,7 @@ cfg.permut_rep = permut_rep;
 cfg.feat_weights_mode = feat_weights_mode;
 cfg.display_on = display_on;
 cfg.perm_disp = perm_disp;
+cfg.normalise_data = normalise_data;
 
 
 

--- a/dd_normalise_data_test.m
+++ b/dd_normalise_data_test.m
@@ -1,0 +1,89 @@
+function [output_data] = dd_normalise_data_test(input_data, feature_min_vals, feature_max_vals)
+%
+% Normalises values within the 0-1 range for each feature. Data are
+% normalised for each feature separately, and are normalised across
+% instances/epochs. Minimum and maximum values computed during this
+% normalisation are then saved for each feature, as these values must also
+% be used to when normalising the test data. Normalisation helps run SVMs
+% much faster, and SVM classification using normalised values can also be
+% more accurate. See the documentation for LIBSVM for further information.
+%
+%
+% Inputs:
+%
+%   input_data  This is a feature by epoch matrix used for training/test
+%               the classifier or regression model. 
+%
+%  feature_min_vals
+%
+%
+%  feature_max_vals
+%
+%
+%		
+% Outputs:
+%
+%  output_data  Normalised data produced by the function, for subsequent
+%               classification or regression with SVMs
+%
+%
+%
+% Usage: [output_data, feature_min_vals, feature_max_vals] = dd_normalise_data(input_data, feature_min_vals, feature_max_vals)
+%
+%
+% Copyright (c) 2013-2019: DDTBOX has been developed by Stefan Bode 
+% and Daniel Feuerriegel with contributions from Daniel Bennett and 
+% Phillip M. Alday. 
+%
+% This file is part of DDTBOX and has been written by Daniel Feuerriegel
+%
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+%% Normalise the Input Data
+
+% Normalise the data to be between 0 and 1 (results in faster SVMs with
+% better performance)
+
+% Normalise within features (across instances), and not across
+% instances/trials! We will also need to save the values calculated
+% during normalisation, so that they can be used to normalise the
+% test set data in exactly the same way.
+
+% Preallocate normalised input data matrix
+norm_input_data = nan(size(input_data, 1), size(input_data, 2));
+
+% Subtract the minimum values from the data for each feature
+for featureNo = 1:size(input_data, 2)
+
+    norm_input_data(:, featureNo) = input_data(:, featureNo) - feature_min_vals(featureNo);
+
+end % of for featureNo
+
+
+% Divide by the maximum values for each feature
+for featureNo = 1:size(norm_input_data, 2)
+
+    norm_input_data(:, featureNo) = norm_input_data(:, featureNo) ./ feature_max_vals(featureNo);
+
+end % of for featureNo
+
+
+
+%% Prepare Outputs
+
+% Allocate normalised data to output_data matrix
+output_data = norm_input_data;
+
+

--- a/dd_normalise_data_test.m
+++ b/dd_normalise_data_test.m
@@ -14,11 +14,11 @@ function [output_data] = dd_normalise_data_test(input_data, feature_min_vals, fe
 %   input_data  This is a feature by epoch matrix used for training/test
 %               the classifier or regression model. 
 %
-%  feature_min_vals
+%  feature_min_vals     Minimum values for each feature, calculated from
+%                       the dataset used for training the classifier.
 %
-%
-%  feature_max_vals
-%
+%  feature_max_vals     Maximum values for each feature, calculated from
+%                       the dataset used for training the classifier.
 %
 %		
 % Outputs:
@@ -28,7 +28,7 @@ function [output_data] = dd_normalise_data_test(input_data, feature_min_vals, fe
 %
 %
 %
-% Usage: [output_data, feature_min_vals, feature_max_vals] = dd_normalise_data(input_data, feature_min_vals, feature_max_vals)
+% Usage: [output_data] = dd_normalise_data(input_data, feature_min_vals, feature_max_vals)
 %
 %
 % Copyright (c) 2013-2019: DDTBOX has been developed by Stefan Bode 
@@ -49,6 +49,7 @@ function [output_data] = dd_normalise_data_test(input_data, feature_min_vals, fe
 % 
 % You should have received a copy of the GNU General Public License
 % along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 
 
 %% Normalise the Input Data

--- a/dd_normalise_data_test.m
+++ b/dd_normalise_data_test.m
@@ -2,11 +2,9 @@ function [output_data] = dd_normalise_data_test(input_data, feature_min_vals, fe
 %
 % Normalises values within the 0-1 range for each feature. Data are
 % normalised for each feature separately, and are normalised across
-% instances/epochs. Minimum and maximum values computed during this
-% normalisation are then saved for each feature, as these values must also
-% be used to when normalising the test data. Normalisation helps run SVMs
-% much faster, and SVM classification using normalised values can also be
-% more accurate. See the documentation for LIBSVM for further information.
+% instances/epochs. Normalisation helps run SVMs much faster, and SVM 
+% classification using normalised values can also be more accurate. 
+% See the documentation for LIBSVM for further information.
 %
 %
 % Inputs:

--- a/dd_normalise_data_training.m
+++ b/dd_normalise_data_training.m
@@ -22,13 +22,18 @@ function [output_data, feature_min_vals, feature_max_vals] = dd_normalise_data_t
 %  output_data  Normalised data produced by the function, for subsequent
 %               classification or regression with SVMs
 %
-%  feature_min_vals
+%  feature_min_vals     Calculated minimum values for each feature, used
+%                       when consequently calculating the maximum values
+%                       and normalising the data. This exact value should also
+%                       be used when normalising the test dataset.
 %
 %
-%  feature_max_vals
+%  feature_max_vals     Calculated maximum values for each feature, used
+%                       when normalising the data. This exact value should also
+%                       be used when normalising the test dataset.
 %
 %
-% Usage: [output_data, feature_min_vals, feature_max_vals] = dd_normalise_data(input_data, feature_min_vals, feature_max_vals)
+% Usage: [output_data, feature_min_vals, feature_max_vals] = dd_normalise_data(input_data)
 %
 %
 % Copyright (c) 2013-2019: DDTBOX has been developed by Stefan Bode 

--- a/dd_normalise_data_training.m
+++ b/dd_normalise_data_training.m
@@ -1,0 +1,101 @@
+function [output_data, feature_min_vals, feature_max_vals] = dd_normalise_data_training(input_data)
+%
+% Normalises values within the 0-1 range for each feature. Data are
+% normalised for each feature separately, and are normalised across
+% instances/epochs. Minimum and maximum values computed during this
+% normalisation are then saved for each feature, as these values must also
+% be used to when normalising the test data. Normalisation helps run SVMs
+% much faster, and SVM classification using normalised values can also be
+% more accurate. See the documentation for LIBSVM for further information.
+%
+%
+% Inputs:
+%
+%   input_data  This is a feature x epoch matrix used for training/test
+%               the classifier or regression model. 
+%
+%
+%
+%		
+% Outputs:
+%
+%  output_data  Normalised data produced by the function, for subsequent
+%               classification or regression with SVMs
+%
+%  feature_min_vals
+%
+%
+%  feature_max_vals
+%
+%
+% Usage: [output_data, feature_min_vals, feature_max_vals] = dd_normalise_data(input_data, feature_min_vals, feature_max_vals)
+%
+%
+% Copyright (c) 2013-2019: DDTBOX has been developed by Stefan Bode 
+% and Daniel Feuerriegel with contributions from Daniel Bennett and 
+% Phillip M. Alday. 
+%
+% This file is part of DDTBOX and has been written by Daniel Feuerriegel
+%
+% DDTBOX is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+%% Normalise the Input Data
+
+% Normalise the data to be between 0 and 1 (results in faster SVMs with
+% better performance)
+
+% Normalise within features (across instances), and not across
+% instances/trials! We will also need to save the values calculated
+% during normalisation, so that they can be used to normalise the
+% test set data in exactly the same way.
+
+% Preallocate normalised input data matrix
+norm_input_data = nan(size(input_data, 1), size(input_data, 2));
+
+% Get minimum values (minimum across instances/epochs) for each feature
+min_by_feature_input_data = min(input_data, [], 1);
+
+% Subtract the minimum values from the data for each feature
+for featureNo = 1:size(input_data, 2)
+
+    norm_input_data(:, featureNo) = input_data(:, featureNo) - min_by_feature_input_data(featureNo);
+
+end % of for featureNo
+
+% Get maximum values (maximum across instances/epochs) for each feature,
+% after subtracting the minimum values for each feature
+max_by_feature_input_data = max(norm_input_data, [], 1);
+
+
+% Divide by the maximum values for each feature
+for featureNo = 1:size(norm_input_data, 2)
+
+    norm_input_data(:, featureNo) = norm_input_data(:, featureNo) ./ max_by_feature_input_data(featureNo);
+
+end % of for featureNo
+
+
+
+%% Prepare Outputs
+
+% Allocate normalised data to output_data matrix
+output_data = norm_input_data;
+
+% Save minimum and maximum values for normalising subsequent data matrices in
+% exactly the same way
+feature_min_vals = min_by_feature_input_data;
+feature_max_vals = max_by_feature_input_data;
+
+

--- a/do_my_classification.m
+++ b/do_my_classification.m
@@ -76,6 +76,13 @@ function [acc, feat_weights, feat_weights_corrected] = do_my_classification(vect
 Samples = vectors_train;
 Labels = labels_train;
 
+% Normalise the training data prior to SVM classification/regression, if selected by user.
+if cfg.normalise_data
+   
+    [Samples, feature_min_vals, feature_max_vals] = dd_normalise_data_training(Samples);
+    
+end % of if cfg.normalise_data
+
 
 %% Training the SVMs
 
@@ -94,6 +101,14 @@ end % of if sum
 %% Define Samples and Labels for Testing
 Samples = vectors_test;
 Labels = labels_test;
+
+% Normalise the test data prior to SVM classification/regression, if selected by user.
+if cfg.normalise_data
+   
+    [Samples] = dd_normalise_data_test(Samples, feature_min_vals, feature_max_vals);
+    
+end % of if cfg.normalise_data
+
 
 
 %% Prediction (Test the Classifier)


### PR DESCRIPTION
Added functions that normalise the training and test data between values 0-1 for each feature. Data is normalised for each feature separately, across instances / epochs. This results in greatly improved speed when training SVM classifiers, and in some cases improved accuracy (see documentation for LIBSVM). Note that the same min/max values are used for normalising the training and test data, which is important to do. 